### PR TITLE
Initial Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@ headless-gl
 ===========
 This is a gutted version of [node-webgl](https://github.com/mikeseven/node-webgl) with no external dependencies, DOM emulation or window handling.  You can use it to create WebGL contexts for GPGPU programming and server-side rendering in node.  It should also work in browsers that support WebGL.
 
+Dependencies
+============
+
+* Opengl
+* GLEW (if running on Linux)
 
 Installation
 ============
@@ -9,7 +14,7 @@ Just do:
 
     npm install gl
     
-Currently only works on OS X.  I think adding Linux should be easy, though Windows may be more complicated.  If you have access to working Linux or Windows systems and want to contribute, please let me know.
+Currently only works on OS X and Linux. If you have access to working Windows system and want to contribute, please let me know.
 
 Usage
 =====
@@ -24,10 +29,10 @@ Example
 Here is an example that creates an offscreen framebuffer, clears it to red, reads the result and writes the image to stdout as a [PPM](http://netpbm.sourceforge.net/doc/ppm.html) :
 
     //Create context
-    var gl = require("gl");
     var width   = 64;
     var height  = 64;
-
+    var gl = require("gl").createContext(width, height);
+    
     //Create texture
     var tex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, tex)
@@ -47,7 +52,7 @@ Here is an example that creates an offscreen framebuffer, clears it to red, read
     gl.readPixels(0, 0, width, height, gl.RGB, gl.UNSIGNED_BYTE, pixels);
     process.stdout.write(["P3\n# gl.ppm\n", width, " ", height, "\n255\n"].join(""));
     for(var i=0; i<pixels.length; ++i) {
-      process.stdout.write(pixels[i] + " ");
+        process.stdout.write(pixels[i] + " ");
     }
 
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -25,7 +25,7 @@
       ],
       'conditions': [
         ['OS=="mac"', {'libraries': ['-framework AGL', '-framework OpenGL']}],
-        ['OS=="linux"', {'libraries': ['-lGL']}],
+        ['OS=="linux"', {'libraries': ['-lGL', '-lGLEW']}],
         ['OS=="win"', {
           'libraries': [ 'opengl32.lib' ],
           'defines' : [

--- a/browser_index.js
+++ b/browser_index.js
@@ -1,26 +1,21 @@
 function createContext() {
-  var canvas = document.createElement("canvas")
-  if(!canvas) {
-    return null
-  }
-  try {
-    var gl = canvas.getContext("experimental-webgl")
-    if(gl) {
-      return gl
+    var canvas = document.createElement("canvas");
+    if (!canvas) {
+        return null;
     }
-  } catch(e) {
-  }
-  try {
-    var gl = canvas.getContext("webgl")
-    if(gl) {
-      return gl
-    }
-  } catch(e) {
-  }
-  return null
+    try {
+        var gl = canvas.getContext("experimental-webgl");
+        if (gl) {
+            return gl;
+        }
+    } catch (e) {}
+    try {
+        var gl = canvas.getContext("webgl");
+        if (gl) {
+            return gl;
+        }
+    } catch (e) {}
+    return null;
 }
 
-module.exports = createContext()
-if(module.exports) {
-  module.exports.createContext = createContext
-}
+module.exports.createContext = createContext;

--- a/example/fbo.js
+++ b/example/fbo.js
@@ -1,15 +1,14 @@
 //Create context
-var gl = require("../index.js");
-var width   = 64;
-var height  = 64;
+var width   = 1056;
+var height  = 1056;
+var gl = require("../index.js").createContext(width, height);
 
-console.log("here2");
+//if you are running this headless with xvfb on linux, comment out the framebuffer code below
 
 //Create texture
 var tex = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex)
 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-
 //Create frame buffer
 var fbo = gl.createFramebuffer();
 gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
@@ -18,11 +17,12 @@ gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex
 //Clear screen to red
 gl.clearColor(1.0, 0.0, 0.0, 1.0);
 gl.clear(gl.COLOR_BUFFER_BIT);
-
 //Write output
 var pixels = new Uint8Array(width * height * 3);
 gl.readPixels(0, 0, width, height, gl.RGB, gl.UNSIGNED_BYTE, pixels);
 process.stdout.write(["P3\n# gl.ppm\n", width, " ", height, "\n255\n"].join(""));
 for(var i=0; i<pixels.length; ++i) {
-  process.stdout.write(pixels[i] + " ");
+    //process.stdout.write(pixels[i] + " ");
 }
+
+gl.destroy();

--- a/index.js
+++ b/index.js
@@ -4,32 +4,29 @@ var WebGLContext = require("./webgl.js");
 
 //Interoperate with node-canvas when available
 (function() {
-  var pGetContext
-  function getContextGLShim(contextid) {
-    if(contextid === "webgl" ||
-       contextid === "experimental-webgl") {
-      if(this._gl_context) {
-        return this._gl_context
-      }
-      this._gl_context = new WebGLContext()
-      return this._gl_context
-    }
-    return pgetContext.call(this, contextid)
-  }
-  try {
-    var Canvas = require("canvas")
-    if(Canvas) {
-      pGetContext = Canvas.prototype.getContext
-      Canvas.prototype.getContext = getContextGLShim
-    }
-  } catch(e) {
-  }
-})()
+    var pGetContext;
 
-//Create global WebGLContext
-module.exports = new WebGLContext()
-if(module.exports) {
-  module.exports.createContext = function() {
-    return new WebGLContext()
-  }
+    function getContextGLShim(contextid) {
+        if (contextid === "webgl" ||
+            contextid === "experimental-webgl") {
+            if (this._gl_context) {
+                return this._gl_context;
+            }
+            this._gl_context = new WebGLContext();
+            return this._gl_context;
+        }
+        return pgetContext.call(this, contextid);
+    }
+    try {
+        var Canvas = require("canvas");
+        if (Canvas) {
+            pGetContext = Canvas.prototype.getContext;
+            Canvas.prototype.getContext = getContextGLShim;
+        }
+    } catch (e) {}
+})();
+
+
+module.exports.createContext = function(width, height) {
+    return new WebGLContext(width, height);
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,12 @@
     "url": "git://github.com/mikolalysenko/headless-gl.git"
   },
   "keywords": [
-    "webgl", "opengl", "gl", "headless", "server", "gpgpu"
+    "webgl",
+    "opengl",
+    "gl",
+    "headless",
+    "server",
+    "gpgpu"
   ],
   "author": "Mikola Lysenko",
   "license": "BSD",

--- a/src/arch_wrapper.h
+++ b/src/arch_wrapper.h
@@ -1,25 +1,25 @@
 #ifndef _INCLUDE_ARCH_WRAPPER_
 #define _INCLUDE_ARCH_WRAPPER_
 
+#define GL_ALIASED_POINT_SIZE_RANGE       0x846D
+#define GL_RED_BITS                       0x0D52
+#define GL_GREEN_BITS                     0x0D53
+#define GL_BLUE_BITS                      0x0D54
+#define GL_ALPHA_BITS                     0x0D55
+#define GL_DEPTH_BITS                     0x0D56
+#define GL_STENCIL_BITS                   0x0D57
+#define GL_LUMINANCE                      0x1909
+#define GL_LUMINANCE_ALPHA                0x190A
+#define GL_GENERATE_MIPMAP_HINT           0x8192
+#define glClearDepthf                     glClearDepth
+#define glDepthRangef                     glDepthRange
+
 #if defined (__APPLE__) || defined(MACOSX)
 
     #include <AGL/agl.h>
 
     #define USE_AGL                           1
     #define GL_CONTEXT_TYPE                   AGLContext
-
-    #define GL_ALIASED_POINT_SIZE_RANGE       0x846D
-    #define GL_RED_BITS                       0x0D52
-    #define GL_GREEN_BITS                     0x0D53
-    #define GL_BLUE_BITS                      0x0D54
-    #define GL_ALPHA_BITS                     0x0D55
-    #define GL_DEPTH_BITS                     0x0D56
-    #define GL_STENCIL_BITS                   0x0D57
-    #define GL_LUMINANCE                      0x1909
-    #define GL_LUMINANCE_ALPHA                0x190A
-    #define GL_GENERATE_MIPMAP_HINT           0x8192
-    #define glClearDepthf                     glClearDepth
-    #define glDepthRangef                     glDepthRange
     
 #elif defined(WIN32)
 
@@ -32,7 +32,11 @@
 #else
 
     //X11 system
-    //Not implemented
+    #include <GL/glew.h>
+    #include <GL/gl.h>
+    #include <GL/glx.h>
+    #define USE_GLX                           1
+    #define GL_CONTEXT_TYPE                   GLXContext
 
 #endif
 #endif

--- a/src/webgl.h
+++ b/src/webgl.h
@@ -43,6 +43,11 @@ public:
   bool initialized;
   bool atExit;
   GL_CONTEXT_TYPE gl_context;
+  #ifdef USE_GLX
+  Display *display;
+  Pixmap pixmap;
+  GLXPixmap glXPixmap;
+  #endif
   std::vector<GLObj*> globjs;
   bool checkContext();
   void registerGLObj(GLObjectType type, GLuint obj);
@@ -51,7 +56,7 @@ public:
   static void disposeAll();
   
   //Constructor/destructor
-  WebGL();
+  WebGL(int width, int height);
   virtual ~WebGL();
   
   JS_METHOD(New);


### PR DESCRIPTION
So tried not to make too many changes, basically just added glx pixmap context support for linux. 
New dependency (for linux) is glew.

I changed the exported gl object to not auto create a context. So one has to call `gl.createContext()` and on Linux one must specify the size of the context with `gl.createContext(width, height)` (this doesn't affect the Apple side. 

There's a note about using a framebuffer in the example. On Linux, as far as I can tell you can't create a gl framebuffer without an active display, but if you start the node process with xvfb you can use xvfb as your display and framebuffer.

Nothing spectacular but should help.
