### PR TITLE
fix: fail to get 2d canvas context

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var WebGLContext = require("./webgl.js");
             this._gl_context = new WebGLContext();
             return this._gl_context;
         }
-        return pgetContext.call(this, contextid);
+        return pGetContext.call(this, contextid);
     }
     try {
         var Canvas = require("canvas");


### PR DESCRIPTION
Fail to get canvas context using canvas.getContext("2d") because of mistype
