### PR TITLE
add libxi-dev to linux dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For general information on building native modules, see the [`node-gyp`](https:/
 * GLEW
 
 ```
-$ sudo apt-get install -y build-essential libxi-dev
+$ sudo apt-get install -y build-essential libxi-dev libglu1-mesa-dev
 ```
 
 #### Windows

--- a/README.md
+++ b/README.md
@@ -37,12 +37,17 @@ For general information on building native modules, see the [`node-gyp`](https:/
 * Python 2.7
 * XCode
 
-#### Linux
+#### Ubuntu/Debian
 
 * Python 2.7
 * A GNU C++ environment (available via the `build-essential` package on `apt`)
+* libxi-dev
 * Working and up to date OpenGL drivers
 * GLEW
+
+```
+$ sudo apt-get install -y build-essential libxi-dev
+```
 
 #### Windows
 


### PR DESCRIPTION
I needed this on both ubuntu and debian (or raspbian rather).

Can we formalize what "Working and up to date OpenGL drivers" and "GLEW" means by `apt` packages? It's always nice if you can provide a single `apt-get` command to cut down on time for devs to get started.