### PR TITLE
move out prebuild config into .prebuildrc + strip binaries

### DIFF
--- a/.prebuildrc
+++ b/.prebuildrc
@@ -1,0 +1,17 @@
+# strip debug info from resulting webgl.node
+strip=true
+
+# abi 11
+target[] = 0.10.40
+
+# abi 14
+target[] = 0.12.7
+
+# abi 42
+target[] = 1.0.4
+
+# abi 43
+target[] = 1.8.4
+
+# abi 44
+target[] = 2.4.0

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "tape test/*.js",
     "build": "node-gyp rebuild --verbose",
-    "prebuild": "prebuild -t 0.10.40 -t 0.12.7 -t 1.0.4 -t 1.8.4 -t 2.4.0",
+    "prebuild": "prebuild",
     "install": "prebuild --download"
   },
   "dependencies": {
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "gl-conformance": "^1.0.0",
-    "prebuild": "^2.4.0",
     "tape": "^4.0.1"
   },
   "repository": {


### PR DESCRIPTION
If you have prebuild installed globally you can just do `$ prebuild` inside the `headless-gl` folder. Stripping binaries also cuts down like 200kb from the resulting `.tar.gz` files.