### PR TITLE
remove unused CoreGraphicss framework on osx

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,7 +33,6 @@
         ['OS=="mac"', {
             'libraries': [
                 '-framework QuartzCore',
-                '-framework CoreGraphics',
                 '-framework Quartz'
             ],
         }],


### PR DESCRIPTION
Using node 4.x I was able to get this building :tada:!  Unfortunately, when running the fbo example I'm seeing this:

```
headless-gl (master)‣ node example/fbo.js
/Users/tmpvar/work/c/headless-gl/node_modules/bindings/bindings.js:83
        throw e
        ^

Error: dlopen(/Users/tmpvar/work/c/headless-gl/build/Release/webgl.node, 1): Library not loaded: /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
  Referenced from: /Users/tmpvar/work/c/headless-gl/build/Release/webgl.node
  Reason: Incompatible library version: webgl.node requires version 64.0.0 or later, but ApplicationServices provides version 1.0.0
    at Error (native)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at bindings (/Users/tmpvar/work/c/headless-gl/node_modules/bindings/bindings.js:76:44)
    at Object.<anonymous> (/Users/tmpvar/work/c/headless-gl/webgl.js:4:35)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
```

Using OSX 10.10.5 w/ Xcode 7.0 (7A220) and node-gyp@v3.0.3.  After very short amount of digging I stumbled on http://stackoverflow.com/questions/13715229/cannot-set-deployment-target-below-osx-10-8-error-dyld-library-not-loaded which seems to have solved the issue. 

This patch removes the (unused?) `CoreGraphics` framework which sidesteps this issue.