### PR TITLE
Prebuild CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "angle"]
 	path = angle
-	url = git@github.com:mikolalysenko/angle.git
+	url = https://github.com/mikolalysenko/angle.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "angle"]
 	path = angle
 	url = https://github.com/mikolalysenko/angle.git
+[submodule "mason"]
+	path = mason
+	url = https://github.com/mapbox/mason.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ matrix:
 addons:
   apt:
     sources: [ 'ubuntu-toolchain-r-test' ]
-    packages: [ 'g++-4.9', 'gcc-4.9' ]
+    packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'libllvm3.4', 'xutils-dev',
+                'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
 
 before_install:
 - ./scripts/install_node.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
   include:
 # Linux
   - os: linux
-    compiler: clang
-    env: CXX=clang++-3.5 NODE_VERSION=0.12
+    compiler: g++
+    env: CXX=g++-4.9 NODE_VERSION=0.12
   - os: linux
-    compiler: clang
-    env: CXX=clang++-3.5 NODE_VERSION=0.10
+    compiler: g++
+    env: CXX=g++-4.9 NODE_VERSION=0.10
 # OS X
   - os: osx
     osx_image: xcode7
@@ -24,8 +24,8 @@ matrix:
 
 addons:
   apt:
-    sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
-    packages: [ 'clang-3.5', 'libstdc++-4.9-dev', 'libstdc++6' ]
+    sources: [ 'ubuntu-toolchain-r-test' ]
+    packages: [ 'g++-4.9', 'gcc-4.9' ]
 
 before_install:
 - ./scripts/install_node.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+# Prevent Travis from exporting CXX after matrix env
+language: c
+
+sudo: false
+
+matrix:
+  include:
+# Linux
+  - os: linux
+    compiler: clang
+    env: CXX=clang++-3.5 NODE_VERSION=0.12
+  - os: linux
+    compiler: clang
+    env: CXX=clang++-3.5 NODE_VERSION=0.10
+# OS X
+  - os: osx
+    osx_image: xcode7
+    compiler: clang
+    env: NODE_VERSION=0.12
+  - os: osx
+    osx_image: xcode7
+    compiler: clang
+    env: NODE_VERSION=0.10
+
+addons:
+  apt:
+    sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
+    packages: [ 'clang-3.5', 'libstdc++-4.9-dev', 'libstdc++6' ]
+
+before_install:
+- ./scripts/install_node.sh
+
+install:
+- ./scripts/install.sh
+
+before_script:
+- ulimit -c unlimited -S
+- ulimit -a
+
+script:
+- ./scripts/test.sh
+
+after_success:
+- ./scripts/after_success.sh
+
+git:
+  submodules: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 It aspires to fully conform to the [WebGL 1.0.3 specification](https://www.khronos.org/registry/webgl/specs/1.0.3/).
 
+[![NPM](https://nodei.co/npm/gl.png?compact=true)](https://nodei.co/npm/gl/)
+[![Build Status](https://travis-ci.org/stackgl/headless-gl.svg?branch=master)](https://travis-ci.org/stackgl/headless-gl)
+
 ## Example
 
 ```javascript

--- a/scripts/after_success.sh
+++ b/scripts/after_success.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# Inspect binary.
+if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
+    ldd ./build/Release/webgl.node
+else
+    otool -L ./build/Release/webgl.node
+fi
+
+COMMIT_MESSAGE=$(git show -s --format=%B $TRAVIS_COMMIT | tr -d '\n')
+PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
+
+if [[ ${TRAVIS_TAG} == v${PACKAGE_JSON_VERSION} ]] || test "${COMMIT_MESSAGE#*'[publish binary]'}" != "$COMMIT_MESSAGE" && [[ ${COVERAGE} == false ]]; then
+    source ~/.nvm/nvm.sh
+    nvm use ${NODE_VERSION}
+
+    npm install --compile --strip
+    ./node_modules/.bin/prebuild --upload ${GITHUB_TOKEN}
+
+    rm -rf build
+    npm install --no-compile
+    npm test
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+source ~/.nvm/nvm.sh
+nvm use ${NODE_VERSION}
+
+npm install --compile

--- a/scripts/install_node.sh
+++ b/scripts/install_node.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+if [ ! -d ~/.nvm ]; then
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash
+fi
+
+source ~/.nvm/nvm.sh
+
+nvm install ${NODE_VERSION}
+nvm alias default ${NODE_VERSION}
+nvm use ${NODE_VERSION}
+
+node --version
+npm --version

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# This script is sourced; do not set -e or -o pipefail here.
+
+git submodule update --init mason
+
+# Ensure mason is on the PATH
+export PATH="`pwd`/mason:${PATH}" MASON_DIR="`pwd`/mason"
+
+# Install Mesa
+mason install mesa 10.4.3
+
+################################################################################
+# X Server setup
+################################################################################
+
+# Start the mock X server
+if [ -f /etc/init.d/xvfb ] ; then
+    sh -e /etc/init.d/xvfb start
+    sleep 2 # sometimes, xvfb takes some time to start up
+fi
+
+# Make sure we're connecting to xvfb
+export DISPLAY=:99.0
+
+# Make sure we're loading the 10.4.3 libs we installed manually
+export LD_LIBRARY_PATH="`mason prefix mesa 10.4.3`/lib:${LD_LIBRARY_PATH:-}"
+
+glxinfo

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,6 +3,10 @@
 set -e
 set -o pipefail
 
+if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
+    source ./scripts/setup.sh
+fi
+
 source ~/.nvm/nvm.sh
 nvm use ${NODE_VERSION}
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+source ~/.nvm/nvm.sh
+nvm use ${NODE_VERSION}
+
+npm test


### PR DESCRIPTION
Refs #23, initial Travis CI configuration with g++-4.9 builds on Linux and clang++-3.5 builds on OS X.

clang++-3.5 builds on Linux were not working because of unsupported options `-fno-tree-sink` and `-fno-tree-vrp`, couldn't track down where these flags were originating from.

https://github.com/stackgl/headless-gl/commit/a59cc9518f4251c0bf260a5f21f4d77d4c9db78c may be unnecessary, I was trying to fix `Error creating WebGLContext`, but I'm seeing this error even on an Ubuntu 14.04 VM with graphics drivers set up correctly. I'm assuming the test failures on OS X are currently expected.

Travis builds for this repository will need to be enabled at https://travis-ci.org/profile/stackgl
<img width="324" alt="screen shot 2015-12-07 at 6 22 47 pm" src="https://cloud.githubusercontent.com/assets/1149913/11646133/8d75f4e2-9d0f-11e5-8e87-e0eb4c423016.png">

A GitHub token will need to be added to the `.travis.yml` file as an [encrypted variable](https://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables) to upload binaries with `prebuild`.