### PR TITLE
Make browser_index compatible with index

### DIFF
--- a/browser_index.js
+++ b/browser_index.js
@@ -30,4 +30,4 @@ function createContext(width, height, options) {
     return null
 }
 
-module.exports.createContext = createContext
+module.exports = createContext;


### PR DESCRIPTION
`browser_index.js` should export in the same fashion as `index.js`, right?