### PR TITLE
[CI appveyor] Platform config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,16 @@
+environment:
+  matrix:
+    - platform: x64
+      configuration: Release
+
 install:
   - cmd: git submodule update --init
-  - cinst nodejs
+  - ps: Install-Product node LTS x64
+  - npm config set msvs_version 2015 --global
+  - npm config set target_arch x64 --global
+  - npm install -g node-gyp
+
+build_script:
   - npm install
 
 test_script:


### PR DESCRIPTION
Editted appveyor config
  Using node.js x64
  Added platform configures

Then, build (`npm install`) can run successful, but test(`npm test`) is not ok as ever.