### PR TITLE
Basic framework for support of the OES_standard_derivatives.

### DIFF
--- a/test/extensions.js
+++ b/test/extensions.js
@@ -2,7 +2,6 @@ var BLACKLIST = [
   // FIXME: These extensions aren't working yet
   'extensions_ext-frag-depth',
   'extensions_ext-shader-texture-lod',
-  'extensions_oes-standard-derivatives',
   'extensions_webgl-draw-buffers'
 ]
 

--- a/webgl.js
+++ b/webgl.js
@@ -215,6 +215,7 @@ function STACKGL_destroy_context () {
 }
 
 function OES_standard_derivatives () {
+  FRAGMENT_SHADER_DERIVATIVE_HINT_OES: 0x8B8B
 }
 
 function unpackTypedArray (array) {

--- a/webgl.js
+++ b/webgl.js
@@ -214,6 +214,9 @@ function STACKGL_resize_drawingbuffer () {
 function STACKGL_destroy_context () {
 }
 
+function OES_standard_derivatives () {
+}
+
 function unpackTypedArray (array) {
   return (new Uint8Array(array.buffer)).subarray(
     array.byteOffset,
@@ -668,7 +671,8 @@ gl.getSupportedExtensions = function getSupportedExtensions () {
   return [
     'ANGLE_instanced_arrays',
     'STACKGL_resize_drawingbuffer',
-    'STACKGL_destroy_context'
+    'STACKGL_destroy_context',
+    'OES_standard_derivatives'
   ]
 }
 
@@ -890,6 +894,9 @@ gl.getExtension = function getExtension (name) {
       ext = new STACKGL_resize_drawingbuffer()
       ext.resize = this.resize.bind(this)
       break
+    case 'OES_standard_derivatives':
+      ext = new OES_standard_derivatives()
+      break;
   }
   if (ext) {
     this._extensions[str] = ext


### PR DESCRIPTION
So I've done a bit of the work to support the OES_standard_derivates extension, but it is not complete.  I am missing how to integrate it with ANGLE.  I notice in the angle code base there is extensions.standardDerivates but I do not see how it is set:

![image](https://cloud.githubusercontent.com/assets/588541/16198143/d23be4d0-36d2-11e6-8478-b19ed9674dc2.png)

I would appreciate some guidance or some existing example code to follow.  Maybe I should be looking at the Chromium source code?

If we could figure out how to do this glue to ANGLE we can likely support a ton of extensions quite quickly.

Thanks for any help.
