### PR TITLE
cubemap creation test

### DIFF
--- a/test/cubeMap.js
+++ b/test/cubeMap.js
@@ -1,0 +1,33 @@
+'use strict'
+
+var tape = require('tape')
+var createContext = require('../index.js')
+
+tape('cube map', function (t) {
+  var width = 64
+  var height = 64
+
+  var gl = createContext(width, height)
+
+  var tex = gl.createTexture()
+  var fb = gl.createFramebuffer()
+  var img = new Uint8Array([255, 255, 255, 255])
+
+  gl.activeTexture(gl.TEXTURE1)
+  gl.bindTexture(gl.TEXTURE_CUBE_MAP, tex)
+  gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+  gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb)
+
+  for (var i = 0; i < 6; i++) {
+    gl.texImage2D(gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, img)
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_CUBE_MAP_POSITIVE_X + i, tex, 0)
+  }
+
+  t.equals(gl.getError(), gl.NO_ERROR, 'checking for gl error after attaching cubemap textures')
+
+  t.end()
+})


### PR DESCRIPTION
New unit test which produces an INVALID_OPERATION error when attempting to attach cubemap textures to a framebuffer. The error occurs after attaching each of the 6 cube sides, but for simplicity the check is performed after they are all done.

(working with @bhouston to debug this)