### PR TITLE
Try blind-fixing the AppVeyor build

### DIFF
--- a/browser_index.js
+++ b/browser_index.js
@@ -16,10 +16,10 @@ function createContext (width, height, options) {
   canvas.height = height
 
   try {
-    gl = canvas.getContext('experimental-webgl', options)
+    gl = canvas.getContext('webgl', options)
   } catch (e) {
     try {
-      gl = canvas.getContext('webgl', options)
+      gl = canvas.getContext('experimental-webgl', options)
     } catch (e) {
       return null
     }


### PR DESCRIPTION
@substack's #85 broke the build on AppVeyor; not sure what's the root cause but apparently it breaks when `webgl` is available but `experimental-webgl` is used instead. This PR swaps them so that `webgl` is used first.