### PR TITLE
Update npmignore (for smaller installs) & dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ node_modules
 prebuilds/*
 angle/build/*
 example/**/*.ppm
+4.6.1
+5.12.0
+6.9.1
+7.0.0
+7.4.0
+8.1.3
+yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,12 @@ example/*
 test/*
 .travis.yml
 appveyor.yml
+build/*
+prebuilds/*
+scripts/*
+4.6.1
+5.12.0
+6.9.1
+7.0.0
+7.4.0
+8.1.3

--- a/example/common/utils.js
+++ b/example/common/utils.js
@@ -52,16 +52,16 @@ function loadShader (gl, shaderSource, shaderType) {
   return shader
 }
 
-function createProgram (gl, shaders, opt_attribs, opt_locations) {
+function createProgram (gl, shaders, optAttribs, optLocations) {
   var program = gl.createProgram()
   shaders.forEach(function (shader) {
     gl.attachShader(program, shader)
   })
-  if (opt_attribs) {
-    opt_attribs.forEach(function (attrib, ndx) {
+  if (optAttribs) {
+    optAttribs.forEach(function (attrib, ndx) {
       gl.bindAttribLocation(
         program,
-        opt_locations ? opt_locations[ndx] : ndx,
+        optLocations ? optLocations[ndx] : ndx,
         attrib)
     })
   }
@@ -80,7 +80,7 @@ function createProgram (gl, shaders, opt_attribs, opt_locations) {
   return program
 }
 
-function createProgramFromSources (gl, shaderSources, opt_attribs, opt_locations) {
+function createProgramFromSources (gl, shaderSources, optAttribs, optLocations) {
   var defaultShaderType = [
     'VERTEX_SHADER',
     'FRAGMENT_SHADER'
@@ -90,7 +90,7 @@ function createProgramFromSources (gl, shaderSources, opt_attribs, opt_locations
   for (var ii = 0; ii < shaderSources.length; ++ii) {
     shaders.push(loadShader(gl, shaderSources[ii], gl[defaultShaderType[ii]]))
   }
-  return createProgram(gl, shaders, opt_attribs, opt_locations)
+  return createProgram(gl, shaders, optAttribs, optLocations)
 }
 
 module.exports.bufferToStdout = bufferToStdout

--- a/example/fractals/mandelbrot.js
+++ b/example/fractals/mandelbrot.js
@@ -2,8 +2,8 @@
 var path = require('path')
 var createContext = require('../../index')
 var utils = require('../common/utils.js')
-var utils_log = require('../common/utils_log.js')
-var log = new utils_log.Log(path.basename(__filename), 'DEBUG')
+var utilsLog = require('../common/utils_log.js')
+var log = new utilsLog.Log(path.basename(__filename), 'DEBUG')
 
 function main () {
   // Create context
@@ -11,14 +11,14 @@ function main () {
   var height = 512
   var gl = createContext(width, height)
 
-  var vertex_src = `
+  var vertexSrc = `
   attribute vec2 a_position;
   void main() {
     gl_Position = vec4(a_position,0,1);
   }
   `
 
-  var fragment_src = `
+  var fragmentSrc = `
   precision mediump float;
   const int max_iterations = 255;
 
@@ -59,7 +59,7 @@ function main () {
   `
 
   // setup a GLSL program
-  var program = utils.createProgramFromSources(gl, [vertex_src, fragment_src])
+  var program = utils.createProgramFromSources(gl, [vertexSrc, fragmentSrc])
 
   if (!program) {
     return

--- a/example/misc/fbo.js
+++ b/example/misc/fbo.js
@@ -3,8 +3,8 @@
 var path = require('path')
 var createContext = require('../../index')
 var utils = require('../common/utils.js')
-var utils_log = require('../common/utils_log.js')
-var log = new utils_log.Log(path.basename(__filename), 'DEBUG')
+var utilsLog = require('../common/utils_log.js')
+var log = new utilsLog.Log(path.basename(__filename), 'DEBUG')
 
 function main () {
   // Create context

--- a/example/test1.js
+++ b/example/test1.js
@@ -7,21 +7,21 @@ function main () {
   var height = 64
   var gl = createContext(width, height)
 
-  var vertex_src = [
+  var vertexSrc = [
     'attribute vec2 a_position;',
     'void main() {',
     'gl_Position = vec4(a_position, 0, 1);',
     '}'
   ].join('\n')
 
-  var fragment_src = [
+  var fragmentSrc = [
     'void main() {',
     'gl_FragColor = vec4(0, 1, 0, 1);  // green',
     '}'
   ].join('\n')
 
   // setup a GLSL program
-  var program = utils.createProgramFromSources(gl, [vertex_src, fragment_src])
+  var program = utils.createProgramFromSources(gl, [vertexSrc, fragmentSrc])
 
   if (!program) {
     return

--- a/example/webgl_fundamentals/test0.js
+++ b/example/webgl_fundamentals/test0.js
@@ -2,8 +2,8 @@
 var path = require('path')
 var createContext = require('../../index')
 var utils = require('../common/utils.js')
-var utils_log = require('../common/utils_log.js')
-var log = new utils_log.Log(path.basename(__filename), 'DEBUG')
+var utilsLog = require('../common/utils_log.js')
+var log = new utilsLog.Log(path.basename(__filename), 'DEBUG')
 
 function main () {
   // Create context
@@ -11,7 +11,7 @@ function main () {
   var height = 512
   var gl = createContext(width, height)
 
-  var vertex_src = `
+  var vertexSrc = `
   attribute vec2 a_position;
 
   void main() {
@@ -19,14 +19,14 @@ function main () {
   }
   `
 
-  var fragment_src = `
+  var fragmentSrc = `
   void main() {
     gl_FragColor = vec4(0, 1, 0, 1);  // green
   }
   `
 
   // setup a GLSL program
-  var program = utils.createProgramFromSources(gl, [vertex_src, fragment_src])
+  var program = utils.createProgramFromSources(gl, [vertexSrc, fragmentSrc])
   gl.useProgram(program)
 
   // look up where the vertex data needs to go.

--- a/example/webgl_fundamentals/test1.js
+++ b/example/webgl_fundamentals/test1.js
@@ -2,8 +2,8 @@
 var path = require('path')
 var createContext = require('../../index')
 var utils = require('../common/utils.js')
-var utils_log = require('../common/utils_log.js')
-var log = new utils_log.Log(path.basename(__filename), 'DEBUG')
+var utilsLog = require('../common/utils_log.js')
+var log = new utilsLog.Log(path.basename(__filename), 'DEBUG')
 
 function main () {
   // Create context
@@ -11,7 +11,7 @@ function main () {
   var height = 512
   var gl = createContext(width, height)
 
-  var vertex_src = `
+  var vertexSrc = `
   attribute vec2 a_position;
 
   uniform vec2 u_resolution;
@@ -30,14 +30,14 @@ function main () {
   }
   `
 
-  var fragment_src = `
+  var fragmentSrc = `
   void main() {
     gl_FragColor = vec4(0, 1, 0, 1);  // green
   }
   `
 
   // setup a GLSL program
-  var program = utils.createProgramFromSources(gl, [vertex_src, fragment_src])
+  var program = utils.createProgramFromSources(gl, [vertexSrc, fragmentSrc])
   gl.useProgram(program)
 
   // look up where the vertex data needs to go.

--- a/package.json
+++ b/package.json
@@ -14,17 +14,18 @@
     "test": "standard | snazzy && tape test/*.js | faucet",
     "rebuild": "node-gyp rebuild --verbose",
     "prebuild": "prebuild --all --strip",
-    "install": "prebuild --install"
+    "install": "prebuild-install || node-gyp rebuild"
   },
   "dependencies": {
     "bindings": "^1.2.1",
     "bit-twiddle": "^1.0.2",
     "glsl-tokenizer": "^2.0.2",
-    "nan": "^2.3.3",
-    "node-gyp": "^3.3.1",
-    "prebuild": "^5.1.2"
+    "nan": "^2.6.2",
+    "node-gyp": "^3.6.2",
+    "prebuild-install": "^2.1.1"
   },
   "devDependencies": {
+    "prebuild": "^6.2.0",
     "angle-normals": "^1.0.0",
     "bunny": "^1.0.1",
     "faucet": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "bunny": "^1.0.1",
     "faucet": "0.0.1",
     "gl-conformance": "^2.0.9",
-    "snazzy": "^3.0.0",
-    "standard": "^6.0.8",
-    "tape": "^4.0.1"
+    "snazzy": "^7.0.0",
+    "standard": "^10.0.2",
+    "tape": "^4.7.0"
   },
   "repository": {
     "type": "git",

--- a/test/alpha-texture.js
+++ b/test/alpha-texture.js
@@ -10,7 +10,7 @@ tape('alpha texture', function (t) {
   var height = 64
   var gl = createContext(width, height)
 
-  var vertex_src = [
+  var vertexSrc = [
     'precision mediump float;',
     'attribute vec2 position;',
     'varying vec2 texCoord;',
@@ -20,7 +20,7 @@ tape('alpha texture', function (t) {
     '}'
   ].join('\n')
 
-  var fragment_src = [
+  var fragmentSrc = [
     'precision mediump float;',
     'uniform sampler2D tex;',
     'varying vec2 texCoord;',
@@ -55,7 +55,7 @@ tape('alpha texture', function (t) {
     gl.UNSIGNED_BYTE,
     data)
 
-  var program = makeShader(gl, vertex_src, fragment_src)
+  var program = makeShader(gl, vertexSrc, fragmentSrc)
 
   gl.useProgram(program)
   gl.uniform1i(gl.getUniformLocation(program, 'tex'), 0)

--- a/test/blending.js
+++ b/test/blending.js
@@ -68,7 +68,7 @@ var tests = [
 for (var j = 0; j < tests.length; j++) {
   var test = tests[j]
   tape(test.name, function (t) {
-    var vertex_src = [
+    var vertexSrc = [
       'precision mediump float;',
       'attribute vec2 position;',
       'void main() {',
@@ -76,7 +76,7 @@ for (var j = 0; j < tests.length; j++) {
       '}'
     ].join('\n')
 
-    var fragment_src = [
+    var fragmentSrc = [
       'precision mediump float;',
       'void main() {',
       'gl_FragColor = ' + test.srcColor,
@@ -86,7 +86,7 @@ for (var j = 0; j < tests.length; j++) {
     gl.clearColor(test.dstColor[0], test.dstColor[1], test.dstColor[2], test.dstColor[3])
     gl.clear(gl.COLOR_BUFFER_BIT)
 
-    var program = makeShader(gl, vertex_src, fragment_src)
+    var program = makeShader(gl, vertexSrc, fragmentSrc)
 
     gl.useProgram(program)
 

--- a/test/depth-buffer.js
+++ b/test/depth-buffer.js
@@ -10,13 +10,13 @@ tape('depth-buffer', function (t) {
   var height = 50
   var gl = createContext(width, height)
 
-  var vertex_src = [
+  var vertexSrc = [
     'attribute vec2 position;',
     'uniform float depth;',
     'void main() { gl_Position = vec4(position,depth,1); }'
   ].join('\n')
 
-  var fragment_src = [
+  var fragmentSrc = [
     'precision mediump float;',
     'uniform vec4 color;',
     'void main() { gl_FragColor = color; }'
@@ -29,7 +29,7 @@ tape('depth-buffer', function (t) {
   gl.enable(gl.DEPTH_TEST)
   gl.depthFunc(gl.NOTEQUAL)
 
-  var program = makeShader(gl, vertex_src, fragment_src)
+  var program = makeShader(gl, vertexSrc, fragmentSrc)
   gl.useProgram(program)
   gl.uniform1f(gl.getUniformLocation(program, 'depth'), 0)
   gl.uniform4f(gl.getUniformLocation(program, 'color'), 1, 0, 0, 1)

--- a/test/draw-indexed.js
+++ b/test/draw-indexed.js
@@ -9,19 +9,19 @@ tape('draw-indexed', function (t) {
   var height = 50
   var gl = createContext(width, height)
 
-  var vertex_src = [
+  var vertexSrc = [
     'attribute vec2 position;',
     'void main() { gl_Position = vec4(position,0,1); }'
   ].join('\n')
 
-  var fragment_src = [
+  var fragmentSrc = [
     'void main() { gl_FragColor = vec4(0,1,0,1); }'
   ].join('\n')
 
   gl.clearColor(1, 0, 0, 1)
   gl.clear(gl.COLOR_BUFFER_BIT)
 
-  var program = makeShader(gl, vertex_src, fragment_src)
+  var program = makeShader(gl, vertexSrc, fragmentSrc)
   gl.useProgram(program)
 
   var vbuffer = gl.createBuffer()

--- a/test/simple-shader.js
+++ b/test/simple-shader.js
@@ -10,19 +10,19 @@ tape('simple-shader', function (t) {
   var height = 50
   var gl = createContext(width, height)
 
-  var vertex_src = [
+  var vertexSrc = [
     'attribute vec2 position;',
     'void main() { gl_Position = vec4(position,0,1); }'
   ].join('\n')
 
-  var fragment_src = [
+  var fragmentSrc = [
     'void main() { gl_FragColor = vec4(0,1,0,1); }'
   ].join('\n')
 
   gl.clearColor(0, 0, 0, 0)
   gl.clear(gl.COLOR_BUFFER_BIT)
 
-  var program = makeShader(gl, vertex_src, fragment_src)
+  var program = makeShader(gl, vertexSrc, fragmentSrc)
   gl.useProgram(program)
   drawTriangle(gl)
 

--- a/webgl.js
+++ b/webgl.js
@@ -205,6 +205,7 @@ function WebGLDrawingBufferWrapper (
 }
 exports.WebGLDrawingBufferWrapper = WebGLDrawingBufferWrapper
 
+/* eslint-disable camelcase */
 function ANGLE_instanced_arrays () {
 }
 
@@ -213,6 +214,7 @@ function STACKGL_resize_drawingbuffer () {
 
 function STACKGL_destroy_context () {
 }
+/* eslint-enable camelcase */
 
 function unpackTypedArray (array) {
   return (new Uint8Array(array.buffer)).subarray(
@@ -224,7 +226,7 @@ function unpackTypedArray (array) {
 function isValidString (str) {
   // Remove comments first
   var c = str.replace(/(?:\/\*(?:[\s\S]*?)\*\/)|(?:([\s;])+\/\/(?:.*)$)/gm, '')
-  return !(/[\"\$\`\@\\\'\0]/.test(c))
+  return !(/["$`@\\'\0]/.test(c))
 }
 
 function isTypedArray (data) {
@@ -272,7 +274,7 @@ function precheckFramebufferStatus (framebuffer) {
   var depthStencilAttachment = attachments[gl.DEPTH_STENCIL_ATTACHMENT]
   var stencilAttachment = attachments[gl.STENCIL_ATTACHMENT]
 
-  if (depthStencilAttachment && (stencilAttachment || depthAttachment) ||
+  if ((depthStencilAttachment && (stencilAttachment || depthAttachment)) ||
       (stencilAttachment && depthAttachment)) {
     return gl.FRAMEBUFFER_UNSUPPORTED
   }
@@ -947,10 +949,8 @@ gl.bindAttribLocation = function bindAttribLocation (program, index, name) {
   name += ''
   if (!isValidString(name) || name.length > MAX_ATTRIBUTE_LENGTH) {
     setError(this, gl.INVALID_VALUE)
-    return
   } else if (/^_?webgl_a/.test(name)) {
     setError(this, gl.INVALID_OPERATION)
-    return
   } else if (checkWrapper(this, program, WebGLProgram)) {
     return _bindAttribLocation.call(
       this,
@@ -1102,7 +1102,7 @@ gl.bindTexture = function bindTexture (target, texture) {
   }
 
   // Get texture id
-  var texture_id = 0
+  var textureId = 0
   if (!texture) {
     texture = null
   } else if (texture instanceof WebGLTexture &&
@@ -1117,7 +1117,7 @@ gl.bindTexture = function bindTexture (target, texture) {
     }
     texture._binding = target
 
-    texture_id = texture._ | 0
+    textureId = texture._ | 0
   } else {
     return
   }
@@ -1126,7 +1126,7 @@ gl.bindTexture = function bindTexture (target, texture) {
   _bindTexture.call(
     this,
     target,
-    texture_id)
+    textureId)
   var error = this.getError()
   restoreError(this, error)
 
@@ -1310,8 +1310,6 @@ gl.bufferData = function bufferData (target, data, usage) {
     if (target === gl.ELEMENT_ARRAY_BUFFER) {
       active._elements = new Uint8Array(u8Data)
     }
-
-    return
   } else if (typeof data === 'number') {
     var size = data | 0
     if (size < 0) {
@@ -1335,11 +1333,8 @@ gl.bufferData = function bufferData (target, data, usage) {
     if (target === gl.ELEMENT_ARRAY_BUFFER) {
       active._elements = new Uint8Array(size)
     }
-
-    return
   } else {
     setError(this, gl.INVALID_VALUE)
-    return
   }
 }
 
@@ -1471,7 +1466,7 @@ function checkShaderSource (context, shader) {
         }
         break
       case 'preprocessor':
-        var bodyToks = tokenize(tok.data.match(/^\s*\#\s*(.*)$/)[1])
+        var bodyToks = tokenize(tok.data.match(/^\s*#\s*(.*)$/)[1])
         for (var j = 0; j < bodyToks.length; ++j) {
           var btok = bodyToks[j]
           if (btok.type === 'ident' || btok.type === void 0) {
@@ -1897,7 +1892,6 @@ gl.depthFunc = function depthFunc (func) {
       return _depthFunc.call(this, func)
     default:
       setError(this, gl.INVALID_ENUM)
-      return
   }
 }
 
@@ -2890,9 +2884,9 @@ gl.getUniformLocation = function getUniformLocation (program, name) {
         var baseName = name.replace(/\[0\]$/, '')
         var arrayLocs = []
 
-        if (offset < 0 || offset >= info.size) {
-          return null
-        }
+        // if (offset < 0 || offset >= info.size) {
+        //   return null
+        // }
 
         saveError(this)
         for (i = 0; this.getError() === gl.NO_ERROR; ++i) {
@@ -3353,7 +3347,6 @@ gl.shaderSource = function shaderSource (shader, source) {
   source += ''
   if (!isValidString(source)) {
     setError(this, gl.INVALID_VALUE)
-    return
   } else if (checkWrapper(this, shader, WebGLShader)) {
     _shaderSource.call(this, shader._ | 0, wrapShader(shader._type, source))
     shader._source = source
@@ -3696,7 +3689,6 @@ gl.texParameterf = function texParameterf (target, pname, param) {
     }
 
     setError(this, gl.INVALID_ENUM)
-    return
   }
 }
 
@@ -3715,7 +3707,6 @@ gl.texParameteri = function texParameteri (target, pname, param) {
     }
 
     setError(this, gl.INVALID_ENUM)
-    return
   }
 }
 
@@ -3789,7 +3780,6 @@ function makeUniforms () {
         }
       } else {
         setError(this, gl.INVALID_VALUE)
-        return
       }
     }
   }
@@ -3808,7 +3798,7 @@ function makeUniforms () {
         if (!checkObject(location)) {
           throw new TypeError(func + '(WebGLUniformLocation, ...)')
         } else if (!location) {
-          return
+
         } else if (checkLocationActive(this, location)) {
           var utype = location._activeInfo.type
           if (utype === gl.SAMPLER_2D ||


### PR DESCRIPTION
- Update dependencies, including new major `prebuild` and `prebuild-install` versions
- Linting fixes for newer `standard`
- Update `.npmignore` for much smaller NPM installs

cc @mikolalysenko @kkaefer