### PR TITLE
Implement OES_element_index_uint support

### DIFF
--- a/webgl.js
+++ b/webgl.js
@@ -671,12 +671,19 @@ gl.getContextAttributes = function () {
 
 var _getSupportedExtensions = gl.getSupportedExtensions
 gl.getSupportedExtensions = function getSupportedExtensions () {
-  return [
+  var exts = [
     'ANGLE_instanced_arrays',
     'STACKGL_resize_drawingbuffer',
-    'STACKGL_destroy_context',
-    'OES_element_index_uint'
+    'STACKGL_destroy_context'
   ]
+
+  var supportedExts = _getSupportedExtensions.call(this)
+
+  if (supportedExts.indexOf('GL_OES_element_index_uint') >= 0) {
+    exts.push('OES_element_index_uint')
+  }
+
+  return exts
 }
 
 function createANGLEInstancedArrays (context) {
@@ -888,9 +895,9 @@ function createANGLEInstancedArrays (context) {
 
 function getOESElementIndexUint (context) {
   var result = null
-  var exts = _getSupportedExtensions.call(context)
+  var exts = context.getSupportedExtensions()
 
-  if (exts && exts.indexOf('GL_OES_element_index_uint') !== -1) {
+  if (exts && exts.indexOf('OES_element_index_uint') !== -1) {
     result = new OESElementIndexUint()
   }
 

--- a/webgl.js
+++ b/webgl.js
@@ -897,7 +897,7 @@ function getOESElementIndexUint (context) {
   var result = null
   var exts = context.getSupportedExtensions()
 
-  if (exts && exts.indexOf('OES_element_index_uint') !== -1) {
+  if (exts && exts.indexOf('OES_element_index_uint') >= 0) {
     result = new OESElementIndexUint()
   }
 

--- a/webgl.js
+++ b/webgl.js
@@ -214,6 +214,9 @@ function STACKGL_resize_drawingbuffer () {
 
 function STACKGL_destroy_context () {
 }
+
+function OESElementIndexUint () {
+}
 /* eslint-enable camelcase */
 
 function unpackTypedArray (array) {
@@ -666,11 +669,13 @@ gl.getContextAttributes = function () {
   return this._contextattributes
 }
 
+var _getSupportedExtensions = gl.getSupportedExtensions
 gl.getSupportedExtensions = function getSupportedExtensions () {
   return [
     'ANGLE_instanced_arrays',
     'STACKGL_resize_drawingbuffer',
-    'STACKGL_destroy_context'
+    'STACKGL_destroy_context',
+    'OES_element_index_uint'
   ]
 }
 
@@ -787,6 +792,13 @@ function createANGLEInstancedArrays (context) {
       }
       offset >>= 1
       elementData = new Uint16Array(elementBuffer._elements.buffer)
+    } else if (context._extensions.oes_element_index_uint && type === gl.UNSIGNED_INT) {
+      if (offset % 4) {
+        setError(context, gl.INVALID_OPERATION)
+        return
+      }
+      offset >>= 2
+      elementData = new Uint32Array(elementBuffer._elements.buffer)
     } else if (type === gl.UNSIGNED_BYTE) {
       elementData = elementBuffer._elements
     } else {
@@ -874,6 +886,17 @@ function createANGLEInstancedArrays (context) {
   return result
 }
 
+function getOESElementIndexUint (context) {
+  var result = null
+  var exts = _getSupportedExtensions.call(context)
+
+  if (exts && exts.indexOf('GL_OES_element_index_uint') !== -1) {
+    result = new OESElementIndexUint()
+  }
+
+  return result
+}
+
 gl.getExtension = function getExtension (name) {
   var str = name.toLowerCase()
   if (str in this._extensions) {
@@ -891,6 +914,9 @@ gl.getExtension = function getExtension (name) {
     case 'stackgl_resize_drawingbuffer':
       ext = new STACKGL_resize_drawingbuffer()
       ext.resize = this.resize.bind(this)
+      break
+    case 'oes_element_index_uint':
+      ext = getOESElementIndexUint(this)
       break
   }
   if (ext) {
@@ -1380,7 +1406,7 @@ gl.bufferSubData = function bufferSubData (target, offset, data) {
   }
 
   if (offset + u8Data.length > active._size) {
-    setError(this, gl.INVALID_OPERATION)
+    setError(this, gl.INVALID_VALUE)
     return
   }
 
@@ -2082,6 +2108,13 @@ gl.drawElements = function drawElements (mode, count, type, ioffset) {
     }
     offset >>= 1
     elementData = new Uint16Array(elementBuffer._elements.buffer)
+  } else if (this._extensions.oes_element_index_uint && type === gl.UNSIGNED_INT) {
+    if (offset % 4) {
+      setError(this, gl.INVALID_OPERATION)
+      return
+    }
+    offset >>= 2
+    elementData = new Uint32Array(elementBuffer._elements.buffer)
   } else if (type === gl.UNSIGNED_BYTE) {
     elementData = elementBuffer._elements
   } else {


### PR DESCRIPTION
I went down a rabbit of trying to debugging why some of my glTF 2 models weren't rendering in headless mode. Turned out they were using unsigned ints for the indices, which requires the `OES_element_index_uint` extension. While, headless-gl doesn't currently support it, I noticed that ANGLE does.

The way I added support:
- Get the list of supported extensions from ANGLE via `getSupportedExtensions` (this seems to be legit, and not contain hardcoded values, as testing on different machines reported different supported extensions)
- Check to see if `GL_OES_element_index_uint ` is in that list
- If it is, return a non-falsy value (that's all that seems to be required). As a bonus, the return value is an instance from an empty constructor called `OESElementIndexUint`, as that's what browsers seem to report.
- Add handling of the data to the `drawElements` method (if the extension is enabled and supported)

Not sure if this is the right way to add support, but it worked for me, and the conformance tests for `OES_element_index_uint` pass.

If this is the right way to do it, perhaps this could be done for #72, as well as other extensions?

Closes #81