### PR TITLE
Fix package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,5 @@
   ],
   "author": "Mikola Lysenko",
   "license": "BSD-2-Clause",
-  "gypfile": true,
-  "readmeFilename": "README.md"
+  "gypfile": true
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gpgpu"
   ],
   "author": "Mikola Lysenko",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "gypfile": true,
   "readmeFilename": "README.md"
 }


### PR DESCRIPTION
Super minor commit. Quells the npm warning about the license value being not a valid SPDX expression.