### PR TITLE
Add pkg-config to dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ In most cases installing `headless-gl` from npm should just work.  However, if y
 * [libxi-dev](http://www.x.org/wiki/)
 * Working and up to date OpenGL drivers
 * [GLEW](http://glew.sourceforge.net/)
+* [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
 
 ```
-$ sudo apt-get install -y build-essential libxi-dev libglu1-mesa-dev libglew-dev
+$ sudo apt-get install -y build-essential libxi-dev libglu1-mesa-dev libglew-dev pkg-config
 ```
 
 #### Windows


### PR DESCRIPTION
I just discovered that `pkg-config` is also a development dependency in my Debian box - without it, running `npm install`  gives me something like:

```
/bin/sh: 1: pkg-config: not found
gyp: Call to 'pkg-config --libs-only-l x11 xi xext' returned exit status 127 while in angle/src/angle.gyp. while loading dependencies of binding.gyp while trying to load binding.gyp
```