### PR TITLE
Fix windows builds for v4.2.x (webgl-draw-buffers)

### DIFF
--- a/src/webgl.cc
+++ b/src/webgl.cc
@@ -2072,12 +2072,15 @@ GL_METHOD(DrawBuffersWEBGL) {
 
   v8::Local<v8::Array> buffersArray = v8::Local<v8::Array>::Cast(info[0]);
   GLuint numBuffers = buffersArray->Length();
-  GLenum buffers[numBuffers];
+  GLenum* buffers = new GLenum[numBuffers];
+
   for (GLuint i = 0; i < numBuffers; i++) {
     buffers[i] = buffersArray->Get(i)->Uint32Value();
   }
 
   (inst->glDrawBuffersEXT)(numBuffers, buffers);
+
+  delete[] buffers;
 }
 
 GL_METHOD(EXTWEBGL_draw_buffers) {

--- a/src/webgl.cc
+++ b/src/webgl.cc
@@ -1062,7 +1062,7 @@ GL_METHOD(BufferSubData) {
 GL_METHOD(BlendEquation) {
   GL_BOILERPLATE;
 
-  GLenum mode = info[0]->Int32Value();;
+  GLenum mode = info[0]->Int32Value();
 
   (inst->glBlendEquation)(mode);
 }


### PR DESCRIPTION
Getting this error in appveyor on v4.2.0:

```
  ..\src\webgl.cc(2075): error C2131: expression did not evaluate to a constant [C:\projects\headless-gl\build\webgl.vcxproj]
1290  ..\src\webgl.cc(2077): error C3863: array type 'GLenum [numBuffers]' is not assignable [C:\projects\headless-gl\build\webgl.vcxproj]
```

gcc doesn't support variable sized arrays, so this method of instantiation is required. Not sure if there's a cleaner / recommended way of achieving this.