### PR TITLE
Drop support of node < 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "browser": "browser_index.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "standard | snazzy && tape test/*.js | faucet",

--- a/scripts/after_success.sh
+++ b/scripts/after_success.sh
@@ -14,5 +14,5 @@ PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
 
 if [[ ${COMMIT_MESSAGE} == ${PACKAGE_JSON_VERSION} ]]; then
   echo "running prebuild"
-  node ./node_modules/prebuild/bin.js --all --strip -u ${GITHUB_TOKEN}
+  node ./node_modules/prebuild/bin.js -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 --strip -u ${GITHUB_TOKEN}
 fi


### PR DESCRIPTION
node 8 is the oldest currently supported version.

Building on node 5 (and possibly 6) causes certain nan/v8 calls to fail. This prevents the build/upload of prebuilt binary artefacts.

Questions:
- should this be a semver major release? If so, should 4.3.0 be unpublished (since it doesn't technically support node < 8)?