### PR TITLE
fix: Check `this._extensions.webgl_draw_buffers` in `gl.drawArrays()`

### DIFF
--- a/webgl.js
+++ b/webgl.js
@@ -2306,7 +2306,13 @@ gl.drawArrays = function drawArrays (mode, first, count) {
     maxIndex = (count + first - 1) >>> 0
   }
   if (checkVertexAttribState(this, maxIndex)) {
-    if (this._vertexAttribs[0]._isPointer) {
+    if (
+      this._vertexAttribs[0]._isPointer || (
+        this._extensions.webgl_draw_buffers &&
+        this._extensions.webgl_draw_buffers._buffersState &&
+        this._extensions.webgl_draw_buffers._buffersState.length > 0
+      )
+    ) {
       return _drawArrays.call(this, mode, first, reducedCount)
     } else {
       beginAttrib0Hack(this)


### PR DESCRIPTION
Fixes #147
Adds a needed check in order to not go into the logic for `beginAttrib0Hack(this)` and `_drawArraysInstanced.call(`, which ends in an error 1282.