### PR TITLE
Make headless-gl context aware

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "test": "standard | snazzy && tape test/*.js | faucet",
+    "test": "standard | snazzy && node --force-context-aware ./node_modules/.bin/tape test/*.js | faucet",
     "rebuild": "node-gyp rebuild --verbose",
     "prebuild": "prebuild --all --strip",
     "install": "prebuild-install || node-gyp rebuild"

--- a/src/native/bindings.cc
+++ b/src/native/bindings.cc
@@ -488,4 +488,8 @@ NAN_MODULE_INIT(Init) {
   Nan::Export(target, "setError", WebGLRenderingContext::SetError);
 }
 
+#if NODE_MAJOR_VERSION >= 10
+NAN_MODULE_WORKER_ENABLED(webgl, Init)
+#else
 NODE_MODULE(webgl, Init)
+#endif


### PR DESCRIPTION
For use in workers, etc.

See
- https://nodejs.org/api/addons.html#addons_context_aware_addons
- https://github.com/nodejs/node/pull/29631
- https://github.com/electron/electron/issues/18397

To do:
- [ ] fix windows test (incorrect way of invoking tape with node CLI args)
- [ ] write a worker test, or something that tests the context-aware nature of this code more concretely
- (in the future) check if we need to implement any global cleanup callbacks, such as the one [here](https://github.com/CharlieHess/node-mac-notifier/pull/32/files). My belief is no, since we don't have any shared state, delegates, etc.