### PR TITLE
Extension: OES_standard_derivatives

### DIFF
--- a/src/javascript/extensions/oes-standard-derivatives.js
+++ b/src/javascript/extensions/oes-standard-derivatives.js
@@ -1,0 +1,18 @@
+class OESStandardDerivatives {
+  constructor () {
+    this.FRAGMENT_SHADER_DERIVATIVE_HINT_OES = 0x8B8B
+  }
+}
+
+function getOESStandardDerivatives (context) {
+  let result = null
+  const exts = context.getSupportedExtensions()
+
+  if (exts && exts.indexOf('OES_standard_derivatives') >= 0) {
+    result = new OESStandardDerivatives()
+  }
+
+  return result
+}
+
+module.exports = { getOESStandardDerivatives, OESStandardDerivatives }

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -830,6 +830,13 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
   }
 
   _wrapShader (type, source) { // eslint-disable-line
+    // the gl implementation seems to define `GL_OES_standard_derivatives` even when the extension is disabled
+    // this behaviour causes one conformance test ('GL_OES_standard_derivatives defined in shaders when extension is disabled') to fail
+    // by `undef`ing `GL_OES_standard_derivatives`, this appears to solve the issue
+    if (!this._extensions.oes_standard_derivatives && /#ifdef\s+GL_OES_standard_derivatives/.test(source)) {
+      source = '#undef GL_OES_standard_derivatives\n' + source
+    }
+
     return this._extensions.webgl_draw_buffers ? source : '#define gl_MaxDrawBuffers 1\n' + source // eslint-disable-line
   }
 

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -186,6 +186,17 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
               break
           }
           break
+        case 'builtin':
+          switch (tok.data) {
+            case 'dFdx':
+            case 'dFdy':
+            case 'fwidth':
+              if (!this._extensions.oes_standard_derivatives) {
+                errorStatus = true
+                errorLog.push(tok.line + ':' + tok.column + ' ' + tok.data + ' not supported')
+              }
+              break
+          }
       }
     }
 

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -2305,7 +2305,7 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
             case ext.MAX_COLOR_ATTACHMENTS_WEBGL:
               return super.getParameter(pname)
           }
-        } else if (this._extensions.oes_standard_derivatives) {
+        } else if (this._extensions.oes_standard_derivatives && this._extensions.oes_standard_derivatives.FRAGMENT_SHADER_DERIVATIVE_HINT_OES === pname) {
           return super.getParameter(pname)
         }
         this.setError(gl.INVALID_ENUM)

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -2305,9 +2305,12 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
             case ext.MAX_COLOR_ATTACHMENTS_WEBGL:
               return super.getParameter(pname)
           }
-        } else if (this._extensions.oes_standard_derivatives && this._extensions.oes_standard_derivatives.FRAGMENT_SHADER_DERIVATIVE_HINT_OES === pname) {
+        }
+
+        if (this._extensions.oes_standard_derivatives && pname === this._extensions.oes_standard_derivatives.FRAGMENT_SHADER_DERIVATIVE_HINT_OES) {
           return super.getParameter(pname)
         }
+        
         this.setError(gl.INVALID_ENUM)
         return null
     }

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -2287,6 +2287,8 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
             case ext.MAX_COLOR_ATTACHMENTS_WEBGL:
               return super.getParameter(pname)
           }
+        } else if (this._extensions.oes_standard_derivatives) {
+          return super.getParameter(pname)
         }
         this.setError(gl.INVALID_ENUM)
         return null

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -2310,7 +2310,7 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
         if (this._extensions.oes_standard_derivatives && pname === this._extensions.oes_standard_derivatives.FRAGMENT_SHADER_DERIVATIVE_HINT_OES) {
           return super.getParameter(pname)
         }
-        
+
         this.setError(gl.INVALID_ENUM)
         return null
     }

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -4,6 +4,7 @@ const HEADLESS_VERSION = require('../../package.json').version
 const { gl, NativeWebGLRenderingContext, NativeWebGL } = require('./native-gl')
 const { getANGLEInstancedArrays } = require('./extensions/angle-instanced-arrays')
 const { getOESElementIndexUint } = require('./extensions/oes-element-index-unit')
+const { getOESStandardDerivatives } = require('./extensions/oes-standard-derivatives')
 const { getOESTextureFloat } = require('./extensions/oes-texture-float')
 const { getSTACKGLDestroyContext } = require('./extensions/stackgl-destroy-context')
 const { getSTACKGLResizeDrawingBuffer } = require('./extensions/stackgl-resize-drawing-buffer')
@@ -52,6 +53,7 @@ const availableExtensions = {
   angle_instanced_arrays: getANGLEInstancedArrays,
   oes_element_index_uint: getOESElementIndexUint,
   oes_texture_float: getOESTextureFloat,
+  oes_standard_derivatives: getOESStandardDerivatives,
   stackgl_destroy_context: getSTACKGLDestroyContext,
   stackgl_resize_drawingbuffer: getSTACKGLResizeDrawingBuffer,
   webgl_draw_buffers: getWebGLDrawBuffers
@@ -1175,6 +1177,10 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
 
     if (supportedExts.indexOf('GL_OES_element_index_uint') >= 0) {
       exts.push('OES_element_index_uint')
+    }
+
+    if (supportedExts.indexOf('GL_OES_standard_derivatives') >= 0) {
+      exts.push('OES_standard_derivatives')
     }
 
     if (supportedExts.indexOf('GL_OES_texture_float') >= 0) {

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -2711,7 +2711,12 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
     target |= 0
     mode |= 0
 
-    if (target !== gl.GENERATE_MIPMAP_HINT) {
+    if (!(
+      target === gl.GENERATE_MIPMAP_HINT ||
+      (
+        this._extensions.oes_standard_derivatives && target === this._extensions.oes_standard_derivatives.FRAGMENT_SHADER_DERIVATIVE_HINT_OES
+      )
+    )) {
       this.setError(gl.INVALID_ENUM)
       return
     }

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -2,7 +2,6 @@ var BLACKLIST = [
   // FIXME: These extensions aren't working yet
   'extensions_ext-frag-depth',
   'extensions_ext-shader-texture-lod',
-  'extensions_oes-standard-derivatives',
   'extensions_webgl-draw-buffers'
 ]
 


### PR DESCRIPTION
Resurrection of #72 
Closes #169 
Closes #72

Adds the use of dFdy, dFdx, and fwidth functions, as well as the FRAGMENT_SHADER_DERIVATIVE_HINT constant.

All tests are passing.

Only issue I came across is `GL_OES_standard_derivatives` seems to be defined globally (in Angle?), when the extension is not enabled. In order to pass the tests, this is dealt with in `_wrapShader`, seemingly without any side-effects.