### PR TITLE
Update C++ version to support Node 16 on Mac

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -41,7 +41,7 @@
               'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
               'MACOSX_DEPLOYMENT_TARGET':'10.8',
               'CLANG_CXX_LIBRARY': 'libc++',
-              'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
+              'CLANG_CXX_LANGUAGE_STANDARD':'c++14',
               'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'
             },
         }],


### PR DESCRIPTION
Compiling on Node 16 currently fails with:

```
/Users/zakjan/Library/Caches/node-gyp/16.2.0/include/node/v8-internal.h:452:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv‘?
```

I tracked it down to that std::remove_cv_t was added in C++14 https://en.cppreference.com/w/cpp/types/remove_cv while headless-gl compilation forces C++11 on Mac https://github.com/stackgl/headless-gl/blob/master/binding.gyp#L44

After updating C++ version, it compiles well. Running tests, I get a test failure which was already reported as #171, so I suppose it's unrelated.