### PR TITLE
Upgrade node-gyp to 8.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "glsl-tokenizer": "^2.0.2",
     "nan": "^2.15.0",
     "node-abi": "^2.30.1",
-    "node-gyp": "^7.1.2",
+    "node-gyp": "^8.2.0",
     "prebuild-install": "^5.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
This is to add support for python3.

Since on debian bullseye it no longer has "python" command by default.