### PR TITLE
Set dimensions of canvas before drawing pixel data into its context

### DIFF
--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -141,6 +141,8 @@ function extractImageData (pixels) {
       const canvas = document.createElement('canvas')
 
       if (typeof canvas === 'object' && typeof canvas.getContext === 'function') {
+        canvas.width = pixels.width
+        canvas.height = pixels.height
         context = canvas.getContext('2d')
 
         if (context !== null) {


### PR DESCRIPTION
Otherwise the canvas may be too small to contain all the image so it would be cropped.

Fixes #232