### PR TITLE
export WebGLRenderingContext and add gl consts

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,3 +3,4 @@ if (typeof WebGLRenderingContext !== 'undefined') {
 } else {
   module.exports = require('./src/javascript/node-index')
 }
+module.exports.WebGLRenderingContext = require('./src/javascript/webgl-rendering-context').WebGLRenderingContext

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -3861,4 +3861,12 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
   }
 }
 
+// Make the gl consts available as static properties
+for (const [key, value] of Object.entries(gl)) {
+  if (typeof value !== 'number') {
+    continue
+  }
+  Object.assign(WebGLRenderingContext, { [key]: value })
+}
+
 module.exports = { WebGLRenderingContext, wrapContext }

--- a/test/webgl-rendering-context.js
+++ b/test/webgl-rendering-context.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const tape = require('tape')
+const WebGLRenderingContext = require('../index').WebGLRenderingContext
+
+tape('use WebGLRenderingContext', function (t) {
+  t.equals(!!WebGLRenderingContext, true)
+  t.equals(!!WebGLRenderingContext.STATIC_DRAW, true)
+  t.equals(!!WebGLRenderingContext.STENCIL_TEST, true)
+  t.equals(!!WebGLRenderingContext.FRAMEBUFFER, true)
+  t.end()
+})


### PR DESCRIPTION
I was trying to use headless-gl to polyfill `window.WebGLRenderingContext` (in addition to `canvas.getContext()`). However, when working with just the class definition instead of a class instance, it was missing the gl consts which are available in the browser implementation. Eg:
`WebGLRenderingContext.STENCIL_TEST`

As a bonus, I also thought it would be nice to have `WebGLRenderingContext` as part of the top level exports instead of having to reach into `gl/src/javascript/webgl-rendering-context`. 

I'm looking for feedback on this solution, as I'm not very familiar with this repo. But instead of just opening an issue, I thought I would try to get a start on some code. 🙂 