### PR TITLE
Add optional chaining to 'name' in getExtension

### DIFF
--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -1175,7 +1175,7 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
   }
 
   getExtension (name) {
-    const str = name.toLowerCase()
+    const str = name?.toLowerCase()
     if (str in this._extensions) {
       return this._extensions[str]
     }


### PR DESCRIPTION
This fixes a bug when a name can be 'null' and an exception will be thrown when calling 'getSupportedExtensions()'. This happened to me when using 'gpu.js' - which has this as a dependency. |