### PR TITLE
fix(*): fix draw elements when WebGLVertexArrayObjectAttribute cleanedUp

### DIFF
--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -1968,7 +1968,13 @@ class WebGLRenderingContext extends NativeWebGLRenderingContext {
 
     if (this._checkVertexAttribState(maxIndex)) {
       if (reducedCount > 0) {
-        if (this._vertexObjectState._attribs[0]._isPointer) {
+        if (
+          this._vertexObjectState._attribs[0]._isPointer || (
+            this._extensions.webgl_draw_buffers &&
+            this._extensions.webgl_draw_buffers._buffersState &&
+            this._extensions.webgl_draw_buffers._buffersState.length > 0
+          )
+        ) {
           return super.drawElements(mode, reducedCount, type, ioffset)
         } else {
           this._beginAttrib0Hack()


### PR DESCRIPTION
Hello! I'm trying to fix this issue with skottie animation

https://github.com/michaeljherrmann/skottie-issue

Under the hood at some point skia, calles WebGLVertexArrayObjectAttribute._clear which sets

`this._vertexObjectState._attribs[0]._isPointer` to false.

and this code executes https://github.com/stackgl/headless-gl/blob/master/src/javascript/webgl-rendering-context.js#L1974-L1976

After that rendering anything with webgl canvas does not any effect.

When I removed `if statement`, it worked fine.


I found this PR https://github.com/stackgl/headless-gl/pull/160
It seems like the problem is similar

Could you validate it? does it make sense?

Thank you!

As a workaround we create new webgl context on every frame 👎 



