### PR TITLE
GitHub Actions: Add Node.js v22 and use runner.os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
@@ -21,13 +21,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - if: startsWith(matrix.os, 'ubuntu')
+      - if: runner.os == 'Linux'
         run: sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
                                      libglew-dev libglu1-mesa-dev libosmesa6
                                      libxi-dev mesa-utils pkg-config
       - run: npm ci
       - run: npm run build --if-present
-      - if: startsWith(matrix.os, 'ubuntu')
+      - if: runner.os == 'Linux'
         run: xvfb-run npm test
-      - if: "!startsWith(matrix.os, 'ubuntu')"
+      - if: runner.os != 'Linux'
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
         run: sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
                                      libglew-dev libglu1-mesa-dev libosmesa6
                                      libxi-dev mesa-utils pkg-config
-      - run: npm ci
+      - run: rm package-lock.json
+      - run: npm install
       - run: npm run build --if-present
       - if: runner.os == 'Linux'
         run: xvfb-run npm test

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "glsl-tokenizer": "^2.1.5",
     "nan": "^2.18.0",
     "node-abi": "^3.56.0",
-    "node-gyp": "^10.0.1",
+    "node-gyp": "^10.2.0",
     "prebuild-install": "^7.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Node.js v22 will fail on GitHub Actions and elsewhere unless `node-gyp==^10.2.0`
* https://github.com/nodejs/node-gyp/releases

GitHub Actions recommendation for detecting the operating system:
* https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#detecting-the-operating-system