### PR TITLE
Add TypeScript type definitions file based on @types/gl.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+declare namespace createContext {
+  interface STACKGL_destroy_context {
+      destroy(): void;
+  }
+
+  interface STACKGL_resize_drawingbuffer {
+      resize(width: GLint, height: GLint): void;
+  }
+
+  interface StackGLExtension {
+      getExtension(extensionName: "STACKGL_destroy_context"): STACKGL_destroy_context | null;
+      getExtension(extensionName: "STACKGL_resize_drawingbuffer"): STACKGL_resize_drawingbuffer | null;
+  }
+
+  const WebGLRenderingContext: WebGLRenderingContext & StackGLExtension & {
+      new(): WebGLRenderingContext & StackGLExtension;
+      prototype: WebGLRenderingContext & StackGLExtension;
+  };
+
+  const WebGL2RenderingContext: WebGL2RenderingContext & StackGLExtension & {
+      new(): WebGL2RenderingContext & StackGLExtension;
+      prototype: WebGL2RenderingContext & StackGLExtension;
+  };
+}
+
+declare function createContext(
+  width: number,
+  height: number,
+  options?: WebGLContextAttributes,
+): WebGLRenderingContext & createContext.StackGLExtension;
+
+export = createContext;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "server",
     "gpgpu"
   ],
+  "types": "index.d.ts",
   "author": "Mikola Lysenko",
   "license": "BSD-2-Clause",
   "gypfile": true


### PR DESCRIPTION
@dhritzkiv another small one, that will make migrating to WebGL 2 easier when using headless-gl with a typescript project.