### PR TITLE
Update gl-conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,7 @@ jobs:
         run: >
           sudo add-apt-repository ppa:kisak/turtle &&
           sudo apt update &&
-          sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
-                                                  libglew-dev libglu1-mesa-dev libosmesa6
-                                                  libxi-dev mesa-utils pkg-config
+          sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa libglew-dev libglu1-mesa-dev libosmesa6 libxi-dev mesa-utils pkg-config
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'npm'
           registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
-        run: |
+        run: >
           sudo add-apt-repository ppa:kisak/turtle &&
           sudo apt update &&
           sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x]
         os: [ubuntu-22.04-arm, windows-2022, macos-14]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
         run: sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
                                      libglew-dev libglu1-mesa-dev libosmesa6
                                      libxi-dev mesa-utils pkg-config
       - run: npm ci
         env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           npm_config_build_from_source: true
           # npm_config_build_from_source is used to force npm post install scripts to build native modules from source instead of downloading prebuilt binaries.
       - run: npm run build --if-present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
+    permissions:
+      packages: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository ppa:kisak/turtle
-          sudo apt update
+          sudo add-apt-repository ppa:kisak/turtle &&
+          sudo apt update &&
           sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
                                                   libglew-dev libglu1-mesa-dev libosmesa6
                                                   libxi-dev mesa-utils pkg-config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x]
-        os: [ubuntu-22.04-arm, windows-2022, macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2022, macos-14]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,12 @@ jobs:
           cache: 'npm'
           registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
-        run: sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
-                                     libglew-dev libglu1-mesa-dev libosmesa6
-                                     libxi-dev mesa-utils pkg-config
+        run: |
+          sudo add-apt-repository ppa:kisak/kisak-mesa
+          sudo apt update
+          sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
+                                                  libglew-dev libglu1-mesa-dev libosmesa6
+                                                  libxi-dev mesa-utils pkg-config
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository ppa:kisak/kisak-mesa
+          sudo add-apt-repository ppa:kisak/turtle
           sudo apt update
           sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
                                                   libglew-dev libglu1-mesa-dev libosmesa6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: npm run build --if-present
+      - run: npm run rebuild
       - if: runner.os == 'Linux'
         run: xvfb-run glxinfo
       - if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,9 @@ jobs:
           sudo add-apt-repository ppa:kisak/turtle &&
           sudo apt update &&
           sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa libglew-dev libglu1-mesa-dev libosmesa6 libxi-dev mesa-utils pkg-config
-      - run: npm ci
+      - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          npm_config_build_from_source: true
-          # npm_config_build_from_source is used to force npm post install scripts to build native modules from source instead of downloading prebuilt binaries.
       - run: npm run build --if-present
       - if: runner.os == 'Linux'
         run: xvfb-run glxinfo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'npm'
           registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
-        run: |
+        run: >
           sudo add-apt-repository ppa:kisak/turtle &&
           sudo apt update &&
           sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,7 @@ jobs:
         run: >
           sudo add-apt-repository ppa:kisak/turtle &&
           sudo apt update &&
-          sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
-                                                  libglew-dev libglu1-mesa-dev libosmesa6
-                                                  libxi-dev mesa-utils pkg-config
+          sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa libglew-dev libglu1-mesa-dev libosmesa6 libxi-dev mesa-utils pkg-config
       - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,13 @@ jobs:
           cache: 'npm'
           registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
-        run: sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
-                                     libglew-dev libglu1-mesa-dev libosmesa6
-                                     libxi-dev mesa-utils pkg-config
+      - if: runner.os == 'Linux'
+        run: |
+          sudo add-apt-repository ppa:kisak/kisak-mesa
+          sudo apt update
+          sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
+                                                  libglew-dev libglu1-mesa-dev libosmesa6
+                                                  libxi-dev mesa-utils pkg-config
       - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository ppa:kisak/kisak-mesa
+          sudo add-apt-repository ppa:kisak/turtle
           sudo apt update
           sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
                                                   libglew-dev libglu1-mesa-dev libosmesa6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository ppa:kisak/turtle
-          sudo apt update
+          sudo add-apt-repository ppa:kisak/turtle &&
+          sudo apt update &&
           sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
                                                   libglew-dev libglu1-mesa-dev libosmesa6
                                                   libxi-dev mesa-utils pkg-config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
           cache: 'npm'
           registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
-      - if: runner.os == 'Linux'
         run: |
           sudo add-apt-repository ppa:kisak/kisak-mesa
           sudo apt update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
         run: sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
                                      libglew-dev libglu1-mesa-dev libosmesa6
                                      libxi-dev mesa-utils pkg-config
       - run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prebuild and Publish
         shell: bash
         run: node ./node_modules/prebuild/bin.js -t ${{ matrix.target }} --strip --include-regex "\.(node|dll)$" -u ${{ secrets.GITHUB_TOKEN }} --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
         run: sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
                                      libglew-dev libglu1-mesa-dev libosmesa6
                                      libxi-dev mesa-utils pkg-config
       - run: npm ci --ignore-scripts
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prebuild and Publish
         shell: bash
         run: node ./node_modules/prebuild/bin.js -t ${{ matrix.target }} --strip --include-regex "\.(node|dll)$" -u ${{ secrets.GITHUB_TOKEN }} --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
       - if: runner.os == 'Linux'
         run: sudo apt-get install -y build-essential libgl1-mesa-dri libglapi-mesa
                                      libglew-dev libglu1-mesa-dev libosmesa6
                                      libxi-dev mesa-utils pkg-config
       - run: npm ci --ignore-scripts
-        env:
-            NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Prebuild and Publish
         shell: bash
         run: node ./node_modules/prebuild/bin.js -t ${{ matrix.target }} --strip --include-regex "\.(node|dll)$" -u ${{ secrets.GITHUB_TOKEN }} --verbose

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@stackgl:registry=https://npm.pkg.github.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@stackgl:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -242,8 +242,6 @@ After you have your [system dependencies installed](#system-dependencies), do th
 
 1. Clone this repo: `git clone git@github.com:stackgl/headless-gl.git`
 1. Switch to the headless gl directory: `cd headless-gl`
-1. Initialize the angle submodule: `git submodule init`
-1. Update the angle submodule: `git submodule update`
 1. Install npm dependencies: `npm install`
 1. Run node-gyp to generate build scripts: `npm run rebuild`
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Prebuilt binaries are generally available for LTS node versions (e.g. 18, 20). I
 
 gl runs on Linux, macOS, and Windows.
 
-Node.js versions 16 and up are supported.
+Node.js versions 18 and up are supported.
 
 ## API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "angle-normals": "^1.0.0",
         "bunny": "^1.0.1",
         "faucet": "^0.0.4",
-        "gl-conformance": "^2.0.9",
+        "gl-conformance": "git+https://github.com/stackgl/gl-conformance/tree/v2.1.0",
         "prebuild": "^13.0.1",
         "snazzy": "^9.0.0",
         "standard": "^17.1.2",
@@ -3468,10 +3468,10 @@
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "node_modules/gl-conformance": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/gl-conformance/-/gl-conformance-2.0.9.tgz",
-      "integrity": "sha512-HkRdl6dKJI0QDMyF3q3EPaApd/tEKlUHVtb13GT7IkFMw5kRxs45j3U1TVYHOjZwvuu6x2dQGAFGpoLBqkpUBg==",
+      "version": "2.1.0",
+      "resolved": "git+ssh://git@github.com/stackgl/gl-conformance.git#110e55f16c205b8d0170927ec67c907e35602cc6",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color": "^0.11.1",
         "concat-stream": "^1.4.6",
@@ -11691,10 +11691,9 @@
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "gl-conformance": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/gl-conformance/-/gl-conformance-2.0.9.tgz",
-      "integrity": "sha512-HkRdl6dKJI0QDMyF3q3EPaApd/tEKlUHVtb13GT7IkFMw5kRxs45j3U1TVYHOjZwvuu6x2dQGAFGpoLBqkpUBg==",
+      "version": "git+ssh://git@github.com/stackgl/gl-conformance.git#110e55f16c205b8d0170927ec67c907e35602cc6",
       "dev": true,
+      "from": "gl-conformance@git+https://github.com/stackgl/gl-conformance/tree/v2.1.0",
       "requires": {
         "color": "^0.11.1",
         "concat-stream": "^1.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,10 @@
         "prebuild-install": "^7.1.3"
       },
       "devDependencies": {
+        "@stackgl/gl-conformance": "2.1.3",
         "angle-normals": "^1.0.0",
         "bunny": "^1.0.1",
         "faucet": "^0.0.4",
-        "gl-conformance": "git+https://github.com/stackgl/gl-conformance/tree/v2.1.0",
         "prebuild": "^13.0.1",
         "snazzy": "^9.0.0",
         "standard": "^17.1.2",
@@ -391,6 +391,154 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@stackgl/gl-conformance": {
+      "version": "2.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@stackgl/gl-conformance/2.1.3/4f6d6aa910c4a68c44630409d176d6dbae55833d",
+      "integrity": "sha512-gjEWhyu4nDJu1RGUFSZ3AfZv4vAQiMcS+1UZhlr82Gjdmlwpad7xJL5mgIu7sTrG0bvhmtSx2lScOnBHKoEFGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^0.11.1",
+        "concat-stream": "^1.4.6",
+        "difference": "^1.0.2",
+        "end-of-stream": "^1.1.0",
+        "glob": "^4.0.6",
+        "js-beautify": "^1.5.4",
+        "ls-stream": "^1.0.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.2.8",
+        "tape": "^4.5.1",
+        "trumpet": "^1.7.0"
+      }
+    },
+    "node_modules/@stackgl/gl-conformance/node_modules/@ljharb/resumer": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ljharb/resumer/-/resumer-0.0.1.tgz",
+      "integrity": "sha512-skQiAOrCfO7vRTq53cxznMpks7wS1va95UCidALlOVWqvBAzwPVErwizDwoMqNVMEn1mDq0utxZd02eIrvF1lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ljharb/through": "^2.3.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/@stackgl/gl-conformance/node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@stackgl/gl-conformance/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stackgl/gl-conformance/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@stackgl/gl-conformance/node_modules/mock-property": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mock-property/-/mock-property-1.0.3.tgz",
+      "integrity": "sha512-2emPTb1reeLLYwHxyVx993iYyCHEiRRO+y8NFXFPL5kl5q14sgTK76cXyEKkeKCHeRw35SfdkUJ10Q1KfHuiIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.1",
+        "functions-have-names": "^1.2.3",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "hasown": "^2.0.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@stackgl/gl-conformance/node_modules/tape": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.17.0.tgz",
+      "integrity": "sha512-KCuXjYxCZ3ru40dmND+oCLsXyuA8hoseu2SS404Px5ouyS0A99v8X/mdiLqsR5MTAyamMBN7PRwt2Dv3+xGIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ljharb/resumer": "~0.0.1",
+        "@ljharb/through": "~2.3.9",
+        "call-bind": "~1.0.2",
+        "deep-equal": "~1.1.1",
+        "defined": "~1.0.1",
+        "dotignore": "~0.1.2",
+        "for-each": "~0.3.3",
+        "glob": "~7.2.3",
+        "has": "~1.0.3",
+        "inherits": "~2.0.4",
+        "is-regex": "~1.1.4",
+        "minimist": "~1.2.8",
+        "mock-property": "~1.0.0",
+        "object-inspect": "~1.12.3",
+        "resolve": "~1.22.6",
+        "string.prototype.trim": "~1.2.8"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@stackgl/gl-conformance/node_modules/tape/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@types/json5": {
@@ -2376,23 +2524,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "1.22.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
-      "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/eslint-module-utils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
@@ -2582,23 +2713,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/eslint-plugin-n/node_modules/resolve": {
-      "version": "1.22.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
-      "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-plugin-n/node_modules/semver": {
@@ -3467,106 +3581,6 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
-    "node_modules/gl-conformance": {
-      "version": "2.1.0",
-      "resolved": "git+ssh://git@github.com/stackgl/gl-conformance.git#110e55f16c205b8d0170927ec67c907e35602cc6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color": "^0.11.1",
-        "concat-stream": "^1.4.6",
-        "difference": "^1.0.2",
-        "end-of-stream": "^1.1.0",
-        "glob": "^4.0.6",
-        "js-beautify": "^1.5.4",
-        "ls-stream": "^1.0.0",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.2.8",
-        "tape": "^4.5.1",
-        "trumpet": "^1.7.0"
-      }
-    },
-    "node_modules/gl-conformance/node_modules/deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
-      "dependencies": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gl-conformance/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/gl-conformance/node_modules/tape": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.15.1.tgz",
-      "integrity": "sha512-k7F5pyr91n9D/yjSJwbLLYDCrTWXxMSXbbmHX2n334lSIc2rxeXyFkaBv4UuUd2gBYMrAOalPutAiCxC6q1qbw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "~1.0.2",
-        "deep-equal": "~1.1.1",
-        "defined": "~1.0.0",
-        "dotignore": "~0.1.2",
-        "for-each": "~0.3.3",
-        "glob": "~7.2.0",
-        "has": "~1.0.3",
-        "inherits": "~2.0.4",
-        "is-regex": "~1.1.4",
-        "minimist": "~1.2.6",
-        "object-inspect": "~1.12.0",
-        "resolve": "~1.22.0",
-        "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.2.5",
-        "through": "~2.3.8"
-      },
-      "bin": {
-        "tape": "bin/tape"
-      }
-    },
-    "node_modules/gl-conformance/node_modules/tape/node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/gl-conformance/node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
     "node_modules/glob": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
@@ -4287,12 +4301,16 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7336,17 +7354,21 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7360,21 +7382,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resumer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true,
-      "dependencies": {
-        "through": "~2.3.4"
-      }
-    },
-    "node_modules/resumer/node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
     },
     "node_modules/retry": {
       "version": "0.12.0",
@@ -9359,6 +9366,119 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "optional": true
     },
+    "@stackgl/gl-conformance": {
+      "version": "2.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@stackgl/gl-conformance/2.1.3/4f6d6aa910c4a68c44630409d176d6dbae55833d",
+      "integrity": "sha512-gjEWhyu4nDJu1RGUFSZ3AfZv4vAQiMcS+1UZhlr82Gjdmlwpad7xJL5mgIu7sTrG0bvhmtSx2lScOnBHKoEFGQ==",
+      "dev": true,
+      "requires": {
+        "color": "^0.11.1",
+        "concat-stream": "^1.4.6",
+        "difference": "^1.0.2",
+        "end-of-stream": "^1.1.0",
+        "glob": "^4.0.6",
+        "js-beautify": "^1.5.4",
+        "ls-stream": "^1.0.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.2.8",
+        "tape": "^4.5.1",
+        "trumpet": "^1.7.0"
+      },
+      "dependencies": {
+        "@ljharb/resumer": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/@ljharb/resumer/-/resumer-0.0.1.tgz",
+          "integrity": "sha512-skQiAOrCfO7vRTq53cxznMpks7wS1va95UCidALlOVWqvBAzwPVErwizDwoMqNVMEn1mDq0utxZd02eIrvF1lw==",
+          "dev": true,
+          "requires": {
+            "@ljharb/through": "^2.3.9"
+          }
+        },
+        "deep-equal": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+          "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+          "dev": true,
+          "requires": {
+            "is-arguments": "^1.1.1",
+            "is-date-object": "^1.0.5",
+            "is-regex": "^1.1.4",
+            "object-is": "^1.1.5",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.5.1"
+          }
+        },
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "mock-property": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/mock-property/-/mock-property-1.0.3.tgz",
+          "integrity": "sha512-2emPTb1reeLLYwHxyVx993iYyCHEiRRO+y8NFXFPL5kl5q14sgTK76cXyEKkeKCHeRw35SfdkUJ10Q1KfHuiIQ==",
+          "dev": true,
+          "requires": {
+            "define-data-property": "^1.1.1",
+            "functions-have-names": "^1.2.3",
+            "gopd": "^1.0.1",
+            "has-property-descriptors": "^1.0.0",
+            "hasown": "^2.0.0",
+            "isarray": "^2.0.5"
+          }
+        },
+        "tape": {
+          "version": "4.17.0",
+          "resolved": "https://registry.npmjs.org/tape/-/tape-4.17.0.tgz",
+          "integrity": "sha512-KCuXjYxCZ3ru40dmND+oCLsXyuA8hoseu2SS404Px5ouyS0A99v8X/mdiLqsR5MTAyamMBN7PRwt2Dv3+xGIxw==",
+          "dev": true,
+          "requires": {
+            "@ljharb/resumer": "~0.0.1",
+            "@ljharb/through": "~2.3.9",
+            "call-bind": "~1.0.2",
+            "deep-equal": "~1.1.1",
+            "defined": "~1.0.1",
+            "dotignore": "~0.1.2",
+            "for-each": "~0.3.3",
+            "glob": "~7.2.3",
+            "has": "~1.0.3",
+            "inherits": "~2.0.4",
+            "is-regex": "~1.1.4",
+            "minimist": "~1.2.8",
+            "mock-property": "~1.0.0",
+            "object-inspect": "~1.12.3",
+            "resolve": "~1.22.6",
+            "string.prototype.trim": "~1.2.8"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+              "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -10876,17 +10996,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "resolve": {
-          "version": "1.22.6",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
-          "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.13.0",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
-          }
         }
       }
     },
@@ -11029,17 +11138,6 @@
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
-          }
-        },
-        "resolve": {
-          "version": "1.22.6",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
-          "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.13.0",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
           }
         },
         "semver": {
@@ -11690,94 +11788,6 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
-    "gl-conformance": {
-      "version": "git+ssh://git@github.com/stackgl/gl-conformance.git#110e55f16c205b8d0170927ec67c907e35602cc6",
-      "dev": true,
-      "from": "gl-conformance@git+https://github.com/stackgl/gl-conformance/tree/v2.1.0",
-      "requires": {
-        "color": "^0.11.1",
-        "concat-stream": "^1.4.6",
-        "difference": "^1.0.2",
-        "end-of-stream": "^1.1.0",
-        "glob": "^4.0.6",
-        "js-beautify": "^1.5.4",
-        "ls-stream": "^1.0.0",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.2.8",
-        "tape": "^4.5.1",
-        "trumpet": "^1.7.0"
-      },
-      "dependencies": {
-        "deep-equal": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-          "dev": true,
-          "requires": {
-            "is-arguments": "^1.0.4",
-            "is-date-object": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "object-is": "^1.0.1",
-            "object-keys": "^1.1.1",
-            "regexp.prototype.flags": "^1.2.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "tape": {
-          "version": "4.15.1",
-          "resolved": "https://registry.npmjs.org/tape/-/tape-4.15.1.tgz",
-          "integrity": "sha512-k7F5pyr91n9D/yjSJwbLLYDCrTWXxMSXbbmHX2n334lSIc2rxeXyFkaBv4UuUd2gBYMrAOalPutAiCxC6q1qbw==",
-          "dev": true,
-          "requires": {
-            "call-bind": "~1.0.2",
-            "deep-equal": "~1.1.1",
-            "defined": "~1.0.0",
-            "dotignore": "~0.1.2",
-            "for-each": "~0.3.3",
-            "glob": "~7.2.0",
-            "has": "~1.0.3",
-            "inherits": "~2.0.4",
-            "is-regex": "~1.1.4",
-            "minimist": "~1.2.6",
-            "object-inspect": "~1.12.0",
-            "resolve": "~1.22.0",
-            "resumer": "~0.0.0",
-            "string.prototype.trim": "~1.2.5",
-            "through": "~2.3.8"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-              "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
-          }
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        }
-      }
-    },
     "glob": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
@@ -12338,12 +12348,12 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
       }
     },
     "is-data-view": {
@@ -14568,12 +14578,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -14583,23 +14593,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
-    },
-    "resumer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true,
-      "requires": {
-        "through": "~2.3.4"
-      },
-      "dependencies": {
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        }
-      }
     },
     "retry": {
       "version": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "angle-normals": "^1.0.0",
     "bunny": "^1.0.1",
     "faucet": "^0.0.4",
-    "gl-conformance": "^2.0.9",
+    "gl-conformance": "git+https://github.com/stackgl/gl-conformance/tree/v2.1.0",
     "prebuild": "^13.0.1",
     "snazzy": "^9.0.0",
     "standard": "^17.1.2",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "prebuild-install": "^7.1.3"
   },
   "devDependencies": {
+    "@stackgl/gl-conformance": "2.1.3",
     "angle-normals": "^1.0.0",
     "bunny": "^1.0.1",
     "faucet": "^0.0.4",
-    "gl-conformance": "git+https://github.com/stackgl/gl-conformance/tree/v2.1.0",
     "prebuild": "^13.0.1",
     "snazzy": "^9.0.0",
     "standard": "^17.1.2",

--- a/test/util/conformance.js
+++ b/test/util/conformance.js
@@ -1,5 +1,5 @@
 const tape = require('tape')
-const runConformance = require('gl-conformance')
+const runConformance = require('@stackgl/gl-conformance')
 const createContext = require('../../index')
 
 // Inject WebGL types into global namespaces, required by some conformance tests


### PR DESCRIPTION
The gl-conformance package has been updated (thanks to the work of @null77 as supported by https://higharc.com/) to reflect the latest conformance suites from Khronos.

However, due to a lack of publishing privileges on npm for specifically the gl-conformance package, I haven't been able to release the update on npm. As a stopgap / workaround, the package has been published to GitHub's Package registry (GHPR) as `@stackgl/gl-conformance`. This workaround has required me to modify the GitHub Actions workflows to support installation from GHPR.

In addition to updating gl-conformance, the following changes were also made:
- include linux-arm64 image in the CI workflow (currently not building successfully)
- separate the build step from the npm install step
- update mesa package to a more recent one