### PR TITLE
fix: macos "C++20 or later required."

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -39,7 +39,7 @@
               'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
               'MACOSX_DEPLOYMENT_TARGET':'10.8',
               'CLANG_CXX_LIBRARY': 'libc++',
-              'CLANG_CXX_LANGUAGE_STANDARD':'c++17',
+              'CLANG_CXX_LANGUAGE_STANDARD':'c++20',
               'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'
             },
             "copies": [


### PR DESCRIPTION
When trying to build the latest version of the package on macOS it fails with the following error:

```
/Users/user/Library/Caches/node-gyp/23.5.0/include/node/v8config.h:13:2: error: "C++20 or later required."
   13 | #error "C++20 or later required."
      |  ^
```

This is caused by the `binding.gyp` file, which sets the CLANG_CXX_LANGUAGE_STANDARD to `c++17`

I've fixed it by setting the c++ standard to 20
