### PR TITLE
feat: add webgl2 uniform buffer methods

### DIFF
--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -642,11 +642,11 @@ class WebGLRenderingContextHelper extends NativeWebGLRenderingContext {
     if (!checkObject(buffer)) {
       throw new TypeError('bindBufferBase(GLenum, GLuint, WebGLBuffer)')
     }
-    
+
     if (!buffer) {
       return super.bindBufferBase(target, index, null)
     } else if (buffer._pendingDelete) {
-      return
+
     } else if (this._checkWrapper(buffer, WebGLBuffer)) {
       return super.bindBufferBase(target, index, buffer._ | 0)
     }
@@ -660,11 +660,11 @@ class WebGLRenderingContextHelper extends NativeWebGLRenderingContext {
     if (!checkObject(buffer)) {
       throw new TypeError('bindBufferRange(GLenum, GLuint, WebGLBuffer, GLintptr, GLsizeiptr)')
     }
-    
+
     if (!buffer) {
       return super.bindBufferRange(target, index, null, offset, size)
     } else if (buffer._pendingDelete) {
-      return
+
     } else if (this._checkWrapper(buffer, WebGLBuffer)) {
       return super.bindBufferRange(target, index, buffer._ | 0, offset, size)
     }
@@ -2833,7 +2833,6 @@ class WebGLRenderingContextHelper extends NativeWebGLRenderingContext {
     }
     if (!program) {
       this.setError(this.INVALID_VALUE)
-      return
     } else if (this._checkWrapper(program, WebGLProgram)) {
       uniformBlockIndex |= 0
       uniformBlockBinding |= 0

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -646,7 +646,7 @@ class WebGLRenderingContextHelper extends NativeWebGLRenderingContext {
     if (!buffer) {
       return super.bindBufferBase(target, index, null)
     } else if (buffer._pendingDelete) {
-
+      //
     } else if (this._checkWrapper(buffer, WebGLBuffer)) {
       return super.bindBufferBase(target, index, buffer._ | 0)
     }
@@ -664,7 +664,7 @@ class WebGLRenderingContextHelper extends NativeWebGLRenderingContext {
     if (!buffer) {
       return super.bindBufferRange(target, index, null, offset, size)
     } else if (buffer._pendingDelete) {
-
+      //
     } else if (this._checkWrapper(buffer, WebGLBuffer)) {
       return super.bindBufferRange(target, index, buffer._ | 0, offset, size)
     }

--- a/src/javascript/webgl-rendering-context.js
+++ b/src/javascript/webgl-rendering-context.js
@@ -636,6 +636,40 @@ class WebGLRenderingContextHelper extends NativeWebGLRenderingContext {
     }
   }
 
+  bindBufferBase (target, index, buffer) {
+    target |= 0
+    index |= 0
+    if (!checkObject(buffer)) {
+      throw new TypeError('bindBufferBase(GLenum, GLuint, WebGLBuffer)')
+    }
+    
+    if (!buffer) {
+      return super.bindBufferBase(target, index, null)
+    } else if (buffer._pendingDelete) {
+      return
+    } else if (this._checkWrapper(buffer, WebGLBuffer)) {
+      return super.bindBufferBase(target, index, buffer._ | 0)
+    }
+  }
+
+  bindBufferRange (target, index, buffer, offset, size) {
+    target |= 0
+    index |= 0
+    offset |= 0
+    size |= 0
+    if (!checkObject(buffer)) {
+      throw new TypeError('bindBufferRange(GLenum, GLuint, WebGLBuffer, GLintptr, GLsizeiptr)')
+    }
+    
+    if (!buffer) {
+      return super.bindBufferRange(target, index, null, offset, size)
+    } else if (buffer._pendingDelete) {
+      return
+    } else if (this._checkWrapper(buffer, WebGLBuffer)) {
+      return super.bindBufferRange(target, index, buffer._ | 0, offset, size)
+    }
+  }
+
   bindRenderbuffer (target, object) {
     if (!checkObject(object)) {
       throw new TypeError('bindRenderbuffer(GLenum, WebGLRenderbuffer)')
@@ -1988,6 +2022,20 @@ class WebGLRenderingContextHelper extends NativeWebGLRenderingContext {
     return null
   }
 
+  getUniformBlockIndex (program, uniformBlockName) {
+    if (!checkObject(program)) {
+      throw new TypeError('getUniformBlockIndex(WebGLProgram, String)')
+    }
+    if (!program) {
+      this.setError(this.INVALID_VALUE)
+      return this.INVALID_INDEX || 0xffffffff
+    } else if (this._checkWrapper(program, WebGLProgram)) {
+      uniformBlockName += ''
+      return super.getUniformBlockIndex(program._ | 0, uniformBlockName)
+    }
+    return this.INVALID_INDEX || 0xffffffff
+  }
+
   getVertexAttrib (index, pname) {
     index |= 0
     pname |= 0
@@ -2777,6 +2825,20 @@ class WebGLRenderingContextHelper extends NativeWebGLRenderingContext {
       return
     }
     this.uniform4i(location, value[0], value[1], value[2], value[3])
+  }
+
+  uniformBlockBinding (program, uniformBlockIndex, uniformBlockBinding) {
+    if (!checkObject(program)) {
+      throw new TypeError('uniformBlockBinding(WebGLProgram, GLuint, GLuint)')
+    }
+    if (!program) {
+      this.setError(this.INVALID_VALUE)
+      return
+    } else if (this._checkWrapper(program, WebGLProgram)) {
+      uniformBlockIndex |= 0
+      uniformBlockBinding |= 0
+      return super.uniformBlockBinding(program._ | 0, uniformBlockIndex, uniformBlockBinding)
+    }
   }
 
   _checkUniformMatrix (location, transpose, value, name, count) {


### PR DESCRIPTION
Implements `bindBufferBase`, `bindBufferRange`, `getUniformBlockIndex`, and `uniformBlockBinding` methods in `WebGLRenderingContextHelper` to support uniform buffer object operations required by WebGL2.