### PR TITLE
Restore eglDestroySurface

### DIFF
--- a/src/native/webgl.cc
+++ b/src/native/webgl.cc
@@ -416,9 +416,7 @@ void WebGLRenderingContext::dispose() {
   ACTIVE = NULL;
 
   // Destroy surface and context
-
-  // FIXME:  This shouldn't be commented out
-  // eglDestroySurface(DISPLAY, surface);
+  eglDestroySurface(DISPLAY, surface);
   eglDestroyContext(DISPLAY, context);
 }
 


### PR DESCRIPTION
In the native WebGLRenderingContext's dispose method, the EGL surface that was created on initialization is never destroyed, causing memory leaks. This is due to the commit below from 2015:

f9ab8893f8cc6f9ae8626a5e7c82952334e474ad - workaround to fix repeated context creation, leaks surfaces for now

This PR uncomments `eglDestroySurface(DISPLAY, surface);`

It's hard to guess why this was done originally, perhaps it was related to context resizing code that was committed at the time. Uncommenting it solved my memory leaks though :)



