### PR TITLE
Update dependencies: update node-gyp to 12.2.0 to fix node-tar vulnerability npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bit-twiddle": "^1.0.2",
     "glsl-tokenizer": "^2.1.5",
     "nan": "^2.24.0",
-    "node-gyp": "^12.1.0",
+    "node-gyp": "^12.2.0",
     "prebuild-install": "^7.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
See node-gyp release post (last bullet point):
https://github.com/nodejs/node-gyp/releases/tag/v12.2.0

Running npm audit on a repository with the latest gl in package.json (^8.1.6), I get:
tar  <=7.5.6
Severity: high

---

Sorry for not adding package-lock.json, npm install failed for me, error:
`npm error 401 Unauthorized - GET https://npm.pkg.github.com/download/@stackgl/gl-conformance/2.1.3/4f6d6aa910c4a68c44630409d176d6dbae55833d - authentication token not provided`
(both on Linux and Windows)

Anyways, using node-gyp 12.2.0 should fix the warning.